### PR TITLE
Add '/api/data/all' to public paths

### DIFF
--- a/nutify/core/auth/api_guard.py
+++ b/nutify/core/auth/api_guard.py
@@ -17,6 +17,7 @@ _PUBLIC_ALWAYS_PATHS = frozenset(
     {
         '/api/frontend/bootstrap',
         '/api/nut_event',
+        '/api/data/all',
     }
 )
 


### PR DESCRIPTION
Make status information viewable without session cookie token for auth

This proposed change enables gethomepage.dev to pull UPS status information without being blocked by api_guard.py as a guarded api path.

<img width="322" height="116" alt="image" src="https://github.com/user-attachments/assets/d1467c73-512e-488c-9171-3b126e5a752a" />
