### PR TITLE
Fix SMTP relay setup with no-auth and IP allowlisting

### DIFF
--- a/nutify/core/mail/mail.py
+++ b/nutify/core/mail/mail.py
@@ -442,6 +442,29 @@ def _build_target_scoped_ups_data(raw_target_id=None, ups_name=None):
         logger.warning(f"Using empty target-scoped UPS data for target_id={target_id}: {exc}")
         return _empty_target_payload(), int(target_id), None
 
+
+def _extract_msmtp_domain(from_email, smtp_server):
+    """Derive the msmtp EHLO domain from the sender address or SMTP host."""
+    domain_pattern = re.compile(
+        r'^(?=.{1,253}$)(?:(?!-)[A-Za-z0-9-]{1,63}(?<!-)\.)+[A-Za-z0-9-]{1,63}$'
+    )
+
+    def _is_valid_domain(value):
+        value = str(value or '').strip().lower()
+        return bool(value) and bool(domain_pattern.fullmatch(value))
+
+    sender = str(from_email or '').strip()
+    if sender and '@' in sender:
+        domain = sender.rsplit('@', 1)[-1].strip()
+        if _is_valid_domain(domain):
+            return domain
+
+    fallback = str(smtp_server or '').strip()
+    if _is_valid_domain(fallback):
+        return fallback
+
+    raise ValueError("Unable to derive a valid SMTP domain")
+
 def get_msmtp_config(config_data):
     """Generate msmtp configuration based on provider and settings"""
     provider = str(config_data.get('provider', '') or '').strip()
@@ -458,14 +481,22 @@ def get_msmtp_config(config_data):
     
     logger.debug(f"🔧 Generating msmtp config for provider: {provider}")
     logger.debug(f"🔧 SMTP Settings: server={smtp_server}, port={smtp_port}")
-    logger.debug(f"🔧 Username: {config_data.get('username', '')}")
+    username = str(config_data.get('username', '') or '').strip()
+    logger.debug(f"🔧 Username: {username}")
     logger.debug(f"🔧 TLS(raw): {config_data.get('tls', config_data.get('use_tls', True))}")
     logger.debug(f"🔧 STARTTLS(raw): {config_data.get('tls_starttls', config_data.get('use_starttls', True))}")
     
-    # Verify password is present and not None
-    if 'password' not in config_data or config_data['password'] is None:
-        logger.error("❌ Password is missing or None in config_data")
-        raise ValueError("Password is required for SMTP configuration")
+    password = config_data.get('password', '')
+    if password is None:
+        password = ''
+    password = str(password)
+
+    if bool(username) != bool(password.strip()):
+        if username:
+            raise ValueError("SMTP password is required when username is set")
+        raise ValueError("SMTP username is required when password is set")
+
+    use_auth = bool(username and password.strip())
     
     # Use from_email if provided, otherwise fall back to username
     # Special handling for providers that require specific sender emails
@@ -480,16 +511,22 @@ def get_msmtp_config(config_data):
     
     # For regular providers (like iCloud, Gmail, etc), it's fine to use username as from_email
     if not from_email:
-        from_email = config_data['username']
-        logger.debug(f"🔧 Using username as from_email: {from_email}")
+        if username:
+            from_email = username
+            logger.debug(f"🔧 Using username as from_email: {from_email}")
+        else:
+            raise ValueError("From email is required when SMTP username is blank")
     else:
         logger.debug(f"🔧 Using explicitly provided from_email: {from_email}")
-    
+
+    msmtp_domain = _extract_msmtp_domain(from_email, smtp_server)
+
     # Base configuration
     config_content = f"""
 # Configuration for msmtp
 defaults
-auth           on
+auth           {'on' if use_auth else 'off'}
+domain         {msmtp_domain}
 """
 
     normalization = normalize_smtp_transport_security(
@@ -532,8 +569,10 @@ account        default
 host           {smtp_server}
 port           {smtp_port}
 from           {from_email}
-user           {config_data['username']}
-password       {config_data['password']}
+"""
+    if use_auth:
+        config_content += f"""user           {username}
+password       {password}
 """
     logger.debug(f"📝 Base msmtp config generated with server: {smtp_server}:{smtp_port}")
 
@@ -567,15 +606,47 @@ def test_email_config(config_data):
         logger.debug(f"📧 Test Configuration:")
         logger.debug(f"📧 Raw config data: {log_config}")
         
+        username = str(config_data.get('username', '') or '').strip()
+        password = config_data.get('password', '')
+        password_is_blank = password is None or str(password).strip() == ''
+
+        if username and password_is_blank:
+            try:
+                # Get the existing configuration from the database
+                mail_model = get_mail_config_model()
+                if not mail_model:
+                    return False, "Mail configuration model not available"
+                mail_query, _ = scoped_mail_query(mail_model, config_data.get('target_id'))
+                existing_config = mail_query.order_by(mail_model.is_default.desc(), mail_model.id.asc()).first()
+                if existing_config and existing_config.password:
+                    logger.debug("🔑 Using existing password from configuration")
+                    decrypted_password = existing_config.password
+                    if decrypted_password is None:
+                        logger.error("❌ Stored password couldn't be decrypted. SECRET_KEY may have changed.")
+                        return False, "Stored password cannot be decrypted. Please enter a new password."
+                    config_data['password'] = decrypted_password
+                else:
+                    logger.error("❌ No existing mail configuration found or password is None")
+                    return False, "No password provided and no valid password stored. Please enter a password."
+            except Exception as de:
+                logger.error(f"❌ Failed to decrypt stored password: {str(de)}")
+                return False, "Stored password cannot be decrypted with the current SECRET_KEY. Please enter a new password."
+        elif username and not password_is_blank:
+            config_data['password'] = password
+        elif not username and not password_is_blank:
+            return False, "SMTP username is required when a password is set"
+        else:
+            config_data['password'] = ''
+
         # Don't override from_email if it's explicitly provided
         # Only set it from username if it doesn't exist or is empty
         if 'from_email' not in config_data or not config_data['from_email']:
-            config_data['from_email'] = config_data.get('username', '')
-            
-        config_data['from_name'] = config_data.get('username', '').split('@')[0] if '@' in config_data.get('username', '') else ''
-            
+            config_data['from_email'] = username
+
+        config_data['from_name'] = username.split('@')[0] if '@' in username else ''
+
         # Ensure required fields are present
-        required_fields = ['smtp_server', 'smtp_port', 'username']
+        required_fields = ['smtp_server', 'smtp_port']
         for field in required_fields:
             if field not in config_data or not config_data[field]:
                 return False, f"Missing required field: {field}"
@@ -587,7 +658,7 @@ def test_email_config(config_data):
         # Get to_email if provided, otherwise use username as fallback
         to_email = config_data.get('to_email')
         if not to_email or to_email.strip() == '':
-            to_email = config_data['username']
+            to_email = username
         logger.debug(f"📧 To Email: {to_email}")
         
         # Validate to_email format
@@ -614,32 +685,7 @@ def test_email_config(config_data):
         logger.debug(f"📧 Provider: {config_data['provider']}")
         logger.debug(f"📧 SMTP Server: {config_data['smtp_server']}")
         logger.debug(f"📧 SMTP Port: {config_data['smtp_port']}")
-        logger.debug(f"📧 Username: {config_data['username']}")
-        
-        # If the password is not provided, use the saved one
-        if 'password' not in config_data or not config_data['password']:
-            try:
-                # Get the existing configuration from the database
-                mail_model = get_mail_config_model()
-                if not mail_model:
-                    return False, "Mail configuration model not available"
-                mail_query, _ = scoped_mail_query(mail_model, config_data.get('target_id'))
-                existing_config = mail_query.order_by(mail_model.is_default.desc(), mail_model.id.asc()).first()
-                if existing_config and existing_config.password:
-                    logger.debug("🔑 Using existing password from configuration")
-                    # Use the password property which automatically decrypts
-                    decrypted_password = existing_config.password
-                    if decrypted_password is None:
-                        logger.error("❌ Stored password couldn't be decrypted. SECRET_KEY may have changed.")
-                        return False, "Stored password cannot be decrypted. Please enter a new password."
-                    config_data['password'] = decrypted_password
-                else:
-                    logger.error("❌ No existing mail configuration found or password is None")
-                    return False, "No password provided and no valid password stored. Please enter a password."
-            except Exception as de:
-                # If it fails to decrypt the saved password, return an explicit error
-                logger.error(f"❌ Failed to decrypt stored password: {str(de)}")
-                return False, "Stored password cannot be decrypted with the current SECRET_KEY. Please enter a new password."
+        logger.debug(f"📧 Username: {username}")
         
         # Generate msmtp configuration
         config_content = get_msmtp_config(config_data)
@@ -782,8 +828,10 @@ def save_mail_config(config_data):
         # Extract other fields
         smtp_server = config_data.get('smtp_server')
         smtp_port = config_data.get('smtp_port')
-        username = config_data.get('smtp_username') or config_data.get('username')
+        username = str(config_data.get('smtp_username') or config_data.get('username') or '').strip()
         password = config_data.get('smtp_password') or config_data.get('password')
+        password_text = '' if password is None else str(password)
+        password_is_blank = password is None or password_text.strip() == ''
         provider = config_data.get('provider')
         to_email = config_data.get('to_email')
         render_mode = normalize_render_mode(config_data.get('render_mode'))
@@ -798,10 +846,10 @@ def save_mail_config(config_data):
         if not smtp_server or not smtp_port:
             logger.error("Required fields missing")
             return False, "SMTP server and port are required"
-        
-        if not username:
-            logger.error("Username missing")
-            return False, "Username is required"
+
+        if not username and not password_is_blank:
+            logger.error("Username missing for authenticated SMTP configuration")
+            return False, "SMTP username is required when password is set"
         
         # Convert port to integer
         try:
@@ -866,14 +914,15 @@ def save_mail_config(config_data):
             except Exception as e:
                 logger.error(f"❌ Failed to encrypt password: {str(e)}")
                 return False, f"Error encrypting password: {str(e)}. Make sure SECRET_KEY is set correctly."
-        elif not config_id and not password:
-            # For new configurations, password is required
-            logger.error("Password required for new configuration")
-            return False, "Password is required for new configuration"
-        elif config_id and not password and config.password is None:
-            # For existing configuration where the saved password can't be decrypted
-            logger.error("❌ Existing password can't be decrypted. SECRET_KEY may have changed.")
-            return False, "Your existing password can't be decrypted. Please provide a new password."
+        elif username:
+            if not config_id:
+                logger.error("Password required for new authenticated configuration")
+                return False, "Password is required when username is set"
+            elif config_id and not password and config.password is None:
+                logger.error("❌ Existing password can't be decrypted. SECRET_KEY may have changed.")
+                return False, "Your existing password can't be decrypted. Please provide a new password."
+        else:
+            config.password = None
         
         # Commit the changes
         db.session.commit()
@@ -2214,8 +2263,24 @@ def interpret_email_error(error_message):
     if "protocol error" in error_lower:
         return "SMTP Protocol Error"
     
-    # Generic msmtp errors from temp files - often encryption related
+    # Generic msmtp errors from temp files - surface the most useful stderr/log tail
     if "msmtp:" in error_lower and "tmp" in error_lower and "could not send mail" in error_lower:
+        def _tail_non_empty_lines(text, limit=3):
+            lines = [line.strip() for line in str(text or '').splitlines() if line.strip()]
+            return lines[-limit:]
+
+        detail_lines = _tail_non_empty_lines(error_message)
+        if not detail_lines:
+            msmtp_log = os.path.expanduser("~/.msmtp.log")
+            if os.path.exists(msmtp_log):
+                try:
+                    with open(msmtp_log, "r", encoding="utf-8", errors="ignore") as log_file:
+                        detail_lines = _tail_non_empty_lines(log_file.read())
+                except Exception as log_error:
+                    logger.debug(f"Could not read msmtp log for error details: {log_error}")
+
+        if detail_lines:
+            return f"Configuration Error: {' | '.join(detail_lines)}"
         return "Configuration Error"
     
     # If no specific match, return a generic but improved message

--- a/nutify/core/mail/mail.py
+++ b/nutify/core/mail/mail.py
@@ -1396,15 +1396,18 @@ class EmailNotifier:
 
             logger.debug(f"Using mail config: ID={mail_config.id}, provider={mail_config.provider}, server={mail_config.smtp_server}")
             logger.debug(f"Mail config has password set: {'Yes' if mail_config.password else 'No'}")
-            
-            # Check if the mail config has a valid password
-            if not mail_config.password:
-                logger.error("Mail config has no password set")
-                return False, "Mail configuration has no password set"
-            
+
+            password_value = mail_config.password
+            if password_value is None:
+                if str(getattr(mail_config, 'username', '') or '').strip():
+                    logger.error("Mail config password is missing or cannot be decrypted for authenticated SMTP")
+                    return False, "Mail configuration password cannot be decrypted. Please update your mail settings with a new password."
+                logger.info("Mail config has no password set; continuing with no-auth SMTP")
+                password_value = ''
+
             # Try to access the password which will test decryption
             try:
-                password_value = mail_config.password
+                password_value = password_value or ''
                 logger.debug(f"Password access successful, length: {len(password_value) if password_value else 0}")
             except Exception as pwd_err:
                 logger.error(f"Failed to access password (likely encryption issue): {str(pwd_err)}")

--- a/nutify/core/report/report.py
+++ b/nutify/core/report/report.py
@@ -2344,37 +2344,31 @@ class ReportManager:
                 if mail_config:
                     logger.info(f"Using mail configuration: SMTP={mail_config.smtp_server}:{mail_config.smtp_port}, Provider={mail_config.provider}")
                     
-                    # Check if the password can be accessed
-                    try:
-                        # First try to get the password directly - this will check if decryption works
-                        password = mail_config.password
-                        if password is None:
-                            logger.error("❌ Mail config password is None or cannot be decrypted")
+                    password = mail_config.password
+                    if password is None:
+                        if str(getattr(mail_config, 'username', '') or '').strip():
+                            logger.error("❌ Mail config password is None or cannot be decrypted for authenticated SMTP")
                             return {
                                 'status': 'error',
                                 'message': 'Mail configuration password cannot be decrypted. Please update your mail settings with a new password.'
                             }
-                        
-                        logger.debug(f"✅ Successfully accessed mail config password (length: {len(password)})")
-                        
-                        smtp_settings = {
-                            'smtp_server': mail_config.smtp_server,  # Use smtp_server key for consistency
-                            'smtp_port': mail_config.smtp_port,      # Use smtp_port key for consistency 
-                            'username': mail_config.username,
-                            'password': password,
-                            'from_email': mail_config.from_email,    # Use from_email property
-                            'provider': mail_config.provider,
-                            'tls': mail_config.tls,                  # Use tls key for consistency
-                            'tls_starttls': mail_config.tls_starttls, # Use tls_starttls key for consistency
-                            # Add a longer timeout for report emails which may be larger
-                            'timeout': 120  # 2 minute timeout for report sending
-                        }
-                    except Exception as pwd_err:
-                        logger.error(f"❌ Failed to access mail config password: {str(pwd_err)}")
-                        return {
-                            'status': 'error',
-                            'message': f'Failed to access mail configuration password: {str(pwd_err)}'
-                        }
+                        logger.info("Mail config has no password set; continuing with no-auth SMTP")
+                        password = ''
+
+                    logger.debug(f"✅ Successfully accessed mail config password (length: {len(password)})")
+
+                    smtp_settings = {
+                        'smtp_server': mail_config.smtp_server,  # Use smtp_server key for consistency
+                        'smtp_port': mail_config.smtp_port,      # Use smtp_port key for consistency 
+                        'username': mail_config.username,
+                        'password': password,
+                        'from_email': mail_config.from_email,    # Use from_email property
+                        'provider': mail_config.provider,
+                        'tls': mail_config.tls,                  # Use tls key for consistency
+                        'tls_starttls': mail_config.tls_starttls, # Use tls_starttls key for consistency
+                        # Add a longer timeout for report emails which may be larger
+                        'timeout': 120  # 2 minute timeout for report sending
+                    }
                 else:
                     logger.error("No mail configuration found")
                     return {

--- a/nutify/frontend/app/src/features/reports/ReportsPage.tsx
+++ b/nutify/frontend/app/src/features/reports/ReportsPage.tsx
@@ -91,7 +91,7 @@ export function ReportsPage() {
       const row = item as Record<string, unknown>
       return {
         id: Number(row.id ?? 0),
-        label: String(row.username ?? `Config ${String(row.id ?? '')}`),
+        label: `${String(row.provider ?? 'Mail')} - ${String(row.to_email ?? row.username ?? `Config ${String(row.id ?? '')}`)}`,
       }
     })
   }, [mailPayload])

--- a/nutify/frontend/app/src/features/settings/sections/MailSection.tsx
+++ b/nutify/frontend/app/src/features/settings/sections/MailSection.tsx
@@ -4,8 +4,6 @@
  * Frontend module used by Nutify React UI flows and state management.
  */
 
-import { useMemo } from 'react'
-
 import { MailConfigPanel } from './mail/MailConfigPanel'
 import { MailNotificationsPanel } from './mail/MailNotificationsPanel'
 import { MailReportSchedulerPanel } from './mail/MailReportSchedulerPanel'
@@ -71,14 +69,10 @@ export function MailSection({
     defaults,
   } = useMailSectionController()
 
-  const validConfigs = useMemo(
-    () => configs.filter((config) => config.username.trim().length > 0),
-    [configs],
-  )
-  const showConfigDependentSections = validConfigs.length > 0 && (!showConfigPanel || !isFormVisible)
+  const showConfigDependentSections = configs.length > 0 && (!showConfigPanel || !isFormVisible)
   const showNotifications = showNotificationsPanel && showConfigDependentSections
   const showReports = showReportPanel && showConfigDependentSections
-  const showMissingProviderCard = (showNotificationsPanel || showReportPanel) && !showConfigPanel && validConfigs.length === 0
+  const showMissingProviderCard = (showNotificationsPanel || showReportPanel) && !showConfigPanel && configs.length === 0
 
   return (
     <>
@@ -90,7 +84,7 @@ export function MailSection({
           isTesting={formTestMutation.isPending}
           form={form}
           providers={providers}
-          configs={validConfigs}
+          configs={configs}
           status={status}
           showSummary={showConfigDependentSections}
           onShowAdd={handleShowAddForm}
@@ -125,7 +119,7 @@ export function MailSection({
       <div id="notification_dependent_sections" style={{ display: showConfigDependentSections ? 'block' : 'none' }}>
         {showNotifications ? (
           <MailNotificationsPanel
-            configs={validConfigs}
+            configs={configs}
             providers={providers}
             selections={selections}
             testBusyEventType={testBusyEventType}
@@ -138,7 +132,7 @@ export function MailSection({
 
         {showReports ? (
           <MailReportSchedulerPanel
-            configs={validConfigs}
+            configs={configs}
             providers={providers}
             reportSettings={reportSettings}
             reportStatus={reportStatus}

--- a/nutify/frontend/app/src/features/settings/sections/NotifySection.tsx
+++ b/nutify/frontend/app/src/features/settings/sections/NotifySection.tsx
@@ -45,14 +45,9 @@ export function NotifySection() {
     return 'active UPS target'
   }, [activeTargetId, targets])
 
-  const validMailConfigs = useMemo(
-    () => mail.configs.filter((config) => config.username.trim().length > 0),
-    [mail.configs],
-  )
-
   const mailOptions = useMemo<SelectOption[]>(
     () =>
-      validMailConfigs.map((config) => {
+      mail.configs.map((config) => {
         const providerLabel =
           mail.providers[config.provider]?.displayName
           || mail.providers[config.provider]?.note
@@ -64,7 +59,7 @@ export function NotifySection() {
           label: `${providerLabel} - ${destination}`,
         }
       }),
-    [mail.providers, validMailConfigs],
+    [mail.providers, mail.configs],
   )
 
   const ntfyOptions = ntfy.configOptions

--- a/nutify/frontend/app/src/features/settings/sections/mail/MailConfigPanel.tsx
+++ b/nutify/frontend/app/src/features/settings/sections/mail/MailConfigPanel.tsx
@@ -57,7 +57,6 @@ export function MailConfigPanel(props: MailConfigPanelProps) {
     onToggleConfigEnabled,
   } = props
 
-  const showFromEmail = Boolean(form.provider && providers[form.provider]?.requires_sender_email)
   const providerNotes =
     form.provider && providers[form.provider]
       ? providers[form.provider].notes || providers[form.provider].note || ''
@@ -179,7 +178,6 @@ export function MailConfigPanel(props: MailConfigPanelProps) {
                 type="text"
                 id="smtp_username"
                 name="smtp_username"
-                required
                 value={form.username}
                 onChange={(event) => onFieldChange('username', event.target.value)}
               />
@@ -217,17 +215,17 @@ export function MailConfigPanel(props: MailConfigPanelProps) {
           </div>
 
           <div className="options_mail_form_grid">
-            <div className="options_mail_form_group" style={{ display: showFromEmail ? 'block' : 'none' }}>
+            <div className="options_mail_form_group" style={{ display: 'block' }}>
               <label htmlFor="from_email">
                 <i className="fas fa-envelope" />
-                <span id="from_email_label">{showFromEmail ? 'From Email (Required)' : 'From Email'}</span>
+                <span id="from_email_label">{form.provider && providers[form.provider]?.requires_sender_email ? 'From Email (Required)' : 'From Email'}</span>
               </label>
               <input
                 type="email"
                 id="from_email"
                 name="from_email"
                 placeholder="Sender email address"
-                required={showFromEmail}
+                required={Boolean(form.provider && providers[form.provider]?.requires_sender_email)}
                 value={form.fromEmail}
                 onChange={(event) => onFieldChange('fromEmail', event.target.value)}
               />


### PR DESCRIPTION
## Summary

Fixes #141.

Three bugs preventing IP-allowlisted SMTP relay setups (Google Workspace SMTP relay, AWS SES IP-based, etc.) from working in v0.2.2:

1. **🔥 msmtp config never emits a `domain` directive**, so msmtp falls back to `EHLO localhost`. Strict relays like Google Workspace SMTP relay reject this with `421 4.7.0 Try again later, closing connection. (EHLO)`. The connection drops, msmtp exits via the generic temp-file path, and `interpret_email_error()` collapses the failure into the bare string `Configuration Error` — giving the user no diagnostic signal.
2. **`From Email` field is hidden for the Gmail provider.** `showFromEmail` only fires when `providers[provider]?.requires_sender_email` is true, which Gmail's preset doesn't set. Users sending unauthenticated through Google's relay can't enter the envelope-from address.
3. **`smtp_username` carries an unconditional `required` attribute,** blocking form submission for any relay configuration that doesn't authenticate.
4. **Saved no-auth configs are hidden from selectors.** The Notify and Mail config selectors filter on `config.username.trim().length > 0`, so a successfully-saved no-auth relay config exists in the database but never appears in the dropdowns. The ReportsPage label also empty-strings when the username is blank.
5. **Send paths hard-require a password.** Even if you bypass the selector, both the event-notification path (`mail.py`) and the report-delivery path (`report.py`) reject configs with empty/None `password` with `"Mail configuration has no password set"`, regardless of whether `username` is also blank.

## Repro

- Google Workspace → Apps → Workspace → Gmail → Routing → SMTP relay service
- Source IP allowlisted, "Only addresses in my domains", no SMTP auth
- Nutify v0.2.2: provider Gmail, host `smtp-relay.gmail.com`, port 587, STARTTLS, **blank** username, **blank** password, valid `from_email`
- Click **Test Email** → `{"message":"Configuration Error","success":false}`

`/root/.msmtp.log` reveals:

```
host=smtp-relay.gmail.com tls=on auth=off from=noreply@example.com errormsg='the server sent an empty reply' exitcode=EX_PROTOCOL
```

`msmtp -d` with the exact config Nutify generates:

```
domain = localhost
--> EHLO localhost
<-- 421-4.7.0 Try again later, closing connection. (EHLO)
```

Same config plus a single `domain example.com` line:

```
<-- 250 2.0.0 OK ... gsmtp
```

## Changes

### `nutify/core/mail/mail.py`

- **New `_extract_msmtp_domain(from_email, smtp_server)`** — derives the EHLO domain from `from_email` (right-split on `@`), validates against a hostname regex (requires at least one dot), falls back to `smtp_server`. Raises `ValueError` if neither yields a valid domain.
- **`get_msmtp_config()`:**
  - Treats `username` and `password` symmetrically — both blank = `auth off`, both set = authenticated, partial = `ValueError` with a specific message instead of a silent failure.
  - Emits `domain {derived_domain}` in every generated config.
  - Only emits `user`/`password` lines when authentication is in use.
  - Requires `from_email` when `username` is blank (the only signal for the EHLO domain in that path).
- **`test_email_config()` and `save_mail_config()`:** drop `username` from `required_fields`, allow blank-credential paths for IP-allowlisted relays, return specific errors for partial-credential states.
- **`interpret_email_error()`:** when the generic msmtp temp-file branch fires, append the last non-empty stderr/log lines (or tail of `~/.msmtp.log`) to the returned message instead of collapsing to `Configuration Error`. This makes the next msmtp-level failure debuggable from the UI alone.

### `nutify/frontend/app/src/features/settings/sections/mail/MailConfigPanel.tsx`

- `From Email` field is now always visible (it's a useful field regardless of provider).
- Label still indicates "(Required)" only for providers that demand it (`requires_sender_email`).
- `smtp_username` no longer has the unconditional `required` attribute.

### `nutify/frontend/app/src/features/settings/sections/notify/NotifySection.tsx` and `nutify/frontend/app/src/features/settings/sections/mail/MailSection.tsx`

- Removed the `config.username.trim().length > 0` filter from both mail-config selectors so saved no-auth SMTP relay configs appear in the dropdown.

### `nutify/frontend/app/src/features/reports/ReportsPage.tsx`

- Updated the config-label fallback so blank-username configs render a useful label instead of an empty string.

### `nutify/core/mail/mail.py` (notification send path) and `nutify/core/report/report.py`

- Both send paths now treat blank password + blank username as a valid no-auth SMTP configuration instead of erroring with `"Mail configuration has no password set"`.
- Authenticated configs (any non-blank username) still fail closed if the password is missing or fails decryption — the relaxation only applies to the symmetric blank-credential case.

## Backward compatibility

Existing authenticated SMTP setups (Gmail with app password, SES with creds, custom relay with auth) emit a byte-equivalent msmtp config except for the new `domain` line, which is additive and supported by msmtp on every version. The auth-skip logic only activates when both `username` and `password` are blank.

## Verification

- `python3 -m py_compile nutify/core/mail/mail.py` ✅
- Patched container deployed and tested via the UI: blank username/password, Gmail provider, port 587 STARTTLS, IP-allowlisted Google Workspace relay → message delivered, `success: true`.
- Manual `msmtp -d` with the patched config emits `domain {sender_domain}`, sends `EHLO {sender_domain}`, receives `250 2.0.0 OK` end-to-end.
- End-to-end via the UI: saved a no-auth relay config, selected it in the Notify dropdown, sent a test event notification → delivered. Repeated for report delivery → delivered.

## Notes for review

- `_extract_msmtp_domain()`'s `smtp_server` fallback is best-effort. The primary path (derived from `from_email`) covers every real configuration; the fallback only fires if `from_email` is malformed *and* `smtp_server` is a valid public hostname. Whether that fallback should be more restrictive is a design call I'd defer to you.
- Two ancillary findings I'm not addressing in this PR (happy to file separately if useful):
  - `LogsSection.tsx` has TypeScript errors that fail a clean `vite build` from `main`. I had to apply this UI change by patching the production bundle in my local container as a result.
  - Files in `/app/nutify/logs/` are 0 bytes despite `logger.debug/error` calls firing — Flask's logger handlers don't appear to be writing.