### PR TITLE
fix: infinite React re-render loop in AppTopbar pegs client CPU at 100% on single-UPS installs

### DIFF
--- a/nutify/frontend/app/src/components/AppTopbar.tsx
+++ b/nutify/frontend/app/src/components/AppTopbar.tsx
@@ -188,7 +188,9 @@ export function AppTopbar() {
     if (monitoringProfile !== 'multi') {
       setFleetOfflineCount(0)
       setFleetAttentionCount(0)
-      setFleetStatusByTarget({})
+      // Keep the same reference when already empty: a fresh {} here re-triggers
+      // this effect (fleetStatusByTarget is a dep) and loops the render cycle.
+      setFleetStatusByTarget((previous) => (Object.keys(previous).length === 0 ? previous : {}))
       return
     }
 


### PR DESCRIPTION
## Summary

As reported in #160

On any install with `monitoring_profile: single` (the default one-UPS setup), the web UI drives one CPU core to 100% on **every page**, including pages with no charts, for as long as a tab is open. The tab's memory footprint also grows into the hundreds of MB from allocation churn.

This is a one-line fix.

## Root cause

The fleet-status effect in `AppTopbar.tsx` (mounted on every page) both **depends on** `fleetStatusByTarget` and **unconditionally sets it** in the non-multi branch:

```tsx
useEffect(() => {
  if (monitoringProfile !== 'multi') {
    setFleetOfflineCount(0)
    setFleetAttentionCount(0)
    setFleetStatusByTarget({})   // new {} identity every pass
    return
  }
  ...
}, [fleetStatusByTarget, monitoringProfile, targets])
```

Each pass creates a fresh `{}`. React sees a changed state value, re-renders, and the effect re-runs because its `fleetStatusByTarget` dep changed, setting another fresh `{}`. The resulting effect -> setState -> effect cycle never settles. The number setters bail out (`0 === 0`), but a new object never equals the previous one.

Multi-profile installs don't hit this: that branch only updates the map via merge-patches and functional updates that return the previous reference when nothing changed.

## Evidence (measured on a live v0.2.0 container, single profile)

- **~5,540 renders/second**: 27,699 `Intl.DateTimeFormat` constructions counted in 5 s (the topbar clock builds one per render, making it the most visible symptom in profiles).
- **V8 CPU profile (8 s)**: 104 ms idle in total, with continuous React scheduler `postMessage` churn. Each render is sub-millisecond, so there are no "long tasks" and the tab looks responsive while a full core burns.
- Chrome Task Manager: Nutify tab at ~100% CPU and ~840 MB footprint while sitting on `/options?view=system` (no charts, no realtime rendering).

## Fix

Return the previous reference when the map is already empty so React's `Object.is` bail-out stops the cycle:

```tsx
setFleetStatusByTarget((previous) => (Object.keys(previous).length === 0 ? previous : {}))
```

## Verification

Applied the equivalent edit to the served bundle on a running v0.2.0 container: tab CPU dropped from ~100% to 0% idle on chart-less pages, and to the normal ~8-12% on pages with the live streaming chart (that cost is the chart's continuous redraw, unchanged by and out of scope for this PR). No behavioral change for multi-profile installs, since the multi branch is untouched.

