### PR TITLE
Fix: notification settings routes ignored target_id, breaking status-change notifications

### DIFF
--- a/nutify/core/mail/api_mail.py
+++ b/nutify/core/mail/api_mail.py
@@ -381,7 +381,8 @@ def register_mail_api_routes(app):
         """Return notification settings."""
         try:
             NotificationSettings = db.ModelClasses.NotificationSettings
-            query, scoped_target_id = _notification_scoped_query(NotificationSettings)
+            requested_target_id = request.args.get('target_id', type=int)
+            query, scoped_target_id = _notification_scoped_query(NotificationSettings, requested_target_id)
             settings = query.order_by(NotificationSettings.event_type.asc()).all()
 
             if not settings:
@@ -418,7 +419,8 @@ def register_mail_api_routes(app):
             
             with data_lock:
                 NotificationSettings = db.ModelClasses.NotificationSettings
-                query, scoped_target_id = _notification_scoped_query(NotificationSettings)
+                requested_target_id = request.args.get('target_id', type=int)
+                query, scoped_target_id = _notification_scoped_query(NotificationSettings, requested_target_id)
                 for setting in data:
                     event_type = str(setting['event_type'])
                     nutify = query.filter(NotificationSettings.event_type == event_type).first()
@@ -473,9 +475,11 @@ def register_mail_api_routes(app):
             enabled = data['enabled']
             id_email = data.get('id_email')
             
+            requested_target_id = request.args.get('target_id', type=int)
+
             with data_lock:
                 NotificationSettings = db.ModelClasses.NotificationSettings
-                query, scoped_target_id = _notification_scoped_query(NotificationSettings)
+                query, scoped_target_id = _notification_scoped_query(NotificationSettings, requested_target_id)
                 nutify = query.filter(NotificationSettings.event_type == event_type).first()
                 
                 if nutify:
@@ -872,7 +876,8 @@ def register_mail_api_routes(app):
                 return jsonify({'success': False, 'error': 'Email configuration not found'}), 404
 
             NotificationSettings = db.ModelClasses.NotificationSettings
-            notification_query, scoped_target_id = _notification_scoped_query(NotificationSettings)
+            requested_target_id = request.args.get('target_id', type=int)
+            notification_query, scoped_target_id = _notification_scoped_query(NotificationSettings, requested_target_id)
             
             # Find all settings that use this email ID
             settings = notification_query.filter(NotificationSettings.id_email == email_id).all()

--- a/nutify/frontend/app/src/features/settings/sections/logs/useLogsSectionController.ts
+++ b/nutify/frontend/app/src/features/settings/sections/logs/useLogsSectionController.ts
@@ -1,0 +1,281 @@
+/** Logs settings section controller: filtering, pagination, clear/download and log settings. */
+
+import { useEffect, useRef, useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  clearLogs,
+  getLogs,
+  getLogSettings,
+  getLogsDownloadUrl,
+  saveLogSettings,
+} from '../../../../lib/api/settings'
+
+const PAGE_SIZE = 500
+const JS_LOGGING_STORAGE_KEY = 'nutify_js_console_logging'
+
+type AlertTone = 'success' | 'error'
+
+type StatusAlert = {
+  tone: AlertTone
+  message: string
+} | null
+
+type LogSettingsState = {
+  log: boolean
+  level: string
+  werkzeug: boolean
+}
+
+type LogLine = {
+  content: string
+  file: string
+  line_number: number
+  level?: string
+}
+
+const DEFAULT_LOG_SETTINGS: LogSettingsState = {
+  log: false,
+  level: 'INFO',
+  werkzeug: false,
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+}
+
+function getMessage(payload: unknown, fallback: string): string {
+  const message = asRecord(payload).message
+  return typeof message === 'string' && message ? message : fallback
+}
+
+function normalizeLines(payload: unknown): { lines: LogLine[]; hasMore: boolean; totalFiles: number } {
+  const data = asRecord(asRecord(payload).data)
+  const rawLines = Array.isArray(data.lines) ? data.lines : []
+  const lines = rawLines
+    .map((row): LogLine | null => {
+      const entry = asRecord(row)
+      if (typeof entry.content !== 'string') return null
+      return {
+        content: entry.content,
+        file: typeof entry.file === 'string' ? entry.file : '',
+        line_number: Number(entry.line_number ?? 0),
+        level: typeof entry.level === 'string' ? entry.level : undefined,
+      }
+    })
+    .filter((row): row is LogLine => row !== null)
+
+  return {
+    lines,
+    hasMore: Boolean(data.has_more),
+    totalFiles: Number(data.total_files ?? 0),
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+function buildLineHtml(line: LogLine): string {
+  const timestampMatch = line.content.match(/^\[([^\]]+)]\s*(.*)$/)
+  const timestamp = timestampMatch ? timestampMatch[1] : ''
+  const rest = timestampMatch ? timestampMatch[2] : line.content
+  const isError = line.level === 'ERROR' || line.level === 'CRITICAL'
+
+  return (
+    '<div class="log-line">' +
+    `<span class="log-file">${escapeHtml(line.file)}</span>` +
+    `<span class="log-number">${line.line_number}</span>` +
+    (timestamp ? `<span class="log-timestamp">${escapeHtml(timestamp)}</span>` : '') +
+    `<span class="log-content${isError ? ' log-error' : ''}">${escapeHtml(rest)}</span>` +
+    '</div>'
+  )
+}
+
+export function useLogsSectionController() {
+  const [alert, setAlert] = useState<StatusAlert>(null)
+  const [logType, setLogType] = useState('all')
+  const [logLevel, setLogLevel] = useState('all')
+  const [dateRange, setDateRange] = useState('today')
+  const [logSettings, setLogSettings] = useState<LogSettingsState>(DEFAULT_LOG_SETTINGS)
+  const [javascriptLogsEnabled, setJavascriptLogsEnabled] = useState(false)
+
+  const [lines, setLines] = useState<LogLine[]>([])
+  const [page, setPage] = useState(1)
+  const [hasMoreLogs, setHasMoreLogs] = useState(false)
+  const [logsLoaded, setLogsLoaded] = useState(false)
+  const [totalFiles, setTotalFiles] = useState(0)
+
+  const [refreshBusy, setRefreshBusy] = useState(false)
+  const [isLoadingLogs, setIsLoadingLogs] = useState(false)
+  const [downloadBusy, setDownloadBusy] = useState(false)
+  const [clearBusy, setClearBusy] = useState(false)
+  const [saveBusy, setSaveBusy] = useState(false)
+
+  const previewRef = useRef<HTMLPreElement>(null)
+
+  const logSettingsQuery = useQuery({
+    queryKey: ['settings', 'logs', 'settings'],
+    queryFn: () => getLogSettings(),
+  })
+
+  useEffect(() => {
+    const data = asRecord(logSettingsQuery.data).data
+    if (!data) return
+    const entry = asRecord(data)
+    setLogSettings({
+      log: Boolean(entry.log),
+      level: typeof entry.level === 'string' ? entry.level : DEFAULT_LOG_SETTINGS.level,
+      werkzeug: Boolean(entry.werkzeug),
+    })
+  }, [logSettingsQuery.data])
+
+  useEffect(() => {
+    setJavascriptLogsEnabled(window.localStorage.getItem(JS_LOGGING_STORAGE_KEY) === 'true')
+  }, [])
+
+  function showAlert(message: string, tone: AlertTone) {
+    setAlert({ tone, message })
+    window.setTimeout(() => setAlert(null), 5000)
+  }
+
+  async function loadLogs(showRefreshSpinner = false) {
+    if (showRefreshSpinner) setRefreshBusy(true)
+    else setIsLoadingLogs(true)
+    try {
+      const payload = await getLogs({ type: logType, level: logLevel, range: dateRange, page: 1, page_size: PAGE_SIZE })
+      const parsed = normalizeLines(payload)
+      setLines(parsed.lines)
+      setPage(1)
+      setHasMoreLogs(parsed.hasMore)
+      setTotalFiles(parsed.totalFiles)
+      setLogsLoaded(true)
+    } catch (error) {
+      showAlert(error instanceof Error ? error.message : 'Failed to load logs', 'error')
+    } finally {
+      if (showRefreshSpinner) setRefreshBusy(false)
+      else setIsLoadingLogs(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadLogs(false)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [logType, logLevel, dateRange])
+
+  async function loadMoreLogs() {
+    if (!hasMoreLogs || isLoadingLogs) return
+    setIsLoadingLogs(true)
+    try {
+      const nextPage = page + 1
+      const payload = await getLogs({
+        type: logType,
+        level: logLevel,
+        range: dateRange,
+        page: nextPage,
+        page_size: PAGE_SIZE,
+      })
+      const parsed = normalizeLines(payload)
+      setLines((previous) => [...previous, ...parsed.lines])
+      setPage(nextPage)
+      setHasMoreLogs(parsed.hasMore)
+    } catch (error) {
+      showAlert(error instanceof Error ? error.message : 'Failed to load more logs', 'error')
+    } finally {
+      setIsLoadingLogs(false)
+    }
+  }
+
+  function handlePreviewScroll(event: React.UIEvent<HTMLPreElement>) {
+    const target = event.currentTarget
+    const nearBottom = target.scrollTop + target.clientHeight >= target.scrollHeight - 48
+    if (nearBottom) void loadMoreLogs()
+  }
+
+  async function handleClearLogs() {
+    setClearBusy(true)
+    try {
+      const payload = await clearLogs(logType)
+      if (asRecord(payload).success === false) {
+        throw new Error(getMessage(payload, 'Failed to clear logs'))
+      }
+      showAlert(getMessage(payload, 'Logs cleared successfully'), 'success')
+      await loadLogs(true)
+    } catch (error) {
+      showAlert(error instanceof Error ? error.message : 'Failed to clear logs', 'error')
+    } finally {
+      setClearBusy(false)
+    }
+  }
+
+  async function handleDownloadLogs() {
+    setDownloadBusy(true)
+    try {
+      window.location.href = getLogsDownloadUrl({ type: logType, level: logLevel, range: dateRange })
+    } finally {
+      window.setTimeout(() => setDownloadBusy(false), 1000)
+    }
+  }
+
+  async function handleSaveAndRestart() {
+    setSaveBusy(true)
+    try {
+      const payload = await saveLogSettings(logSettings)
+      if (asRecord(payload).success === false) {
+        throw new Error(getMessage(payload, 'Failed to save log settings'))
+      }
+      showAlert('Log settings saved. Restarting the application...', 'success')
+      window.setTimeout(() => {
+        void fetch('/api/restart', { method: 'POST', credentials: 'same-origin' }).finally(() => {
+          window.setTimeout(() => window.location.reload(), 2500)
+        })
+      }, 1000)
+    } catch (error) {
+      showAlert(error instanceof Error ? error.message : 'Failed to save log settings', 'error')
+      setSaveBusy(false)
+    }
+  }
+
+  function updateJavascriptLogging(enabled: boolean) {
+    window.localStorage.setItem(JS_LOGGING_STORAGE_KEY, enabled ? 'true' : 'false')
+  }
+
+  const previewHtml = lines.map(buildLineHtml).join('')
+  const logCountText = logsLoaded ? `${lines.length} entries · ${totalFiles} file${totalFiles === 1 ? '' : 's'}` : ''
+
+  return {
+    alert,
+    clearBusy,
+    dateRange,
+    downloadBusy,
+    handleClearLogs,
+    handleDownloadLogs,
+    handlePreviewScroll,
+    handleSaveAndRestart,
+    hasMoreLogs,
+    isLoadingLogs,
+    javascriptLogsEnabled,
+    loadLogs,
+    loadMoreLogs,
+    logCountText,
+    logLevel,
+    logSettings,
+    logType,
+    logsLoaded,
+    previewHtml,
+    previewRef,
+    refreshBusy,
+    saveBusy,
+    setDateRange,
+    setJavascriptLogsEnabled,
+    setLogLevel,
+    setLogSettings,
+    setLogType,
+    showAlert,
+    updateJavascriptLogging,
+  }
+}


### PR DESCRIPTION
## Problem

After upgrading to v0.2.0, email/ntfy/telegram/webhook notifications for UPS status changes (ONBATT, ONLINE, etc.) stopped firing, even though the Notify settings page showed them as configured and enabled. The Test Center also failed with "No notification settings found".

## Root cause

`/api/settings/nutify` (GET/POST) and `/api/settings/nutify/single` in `core/mail/api_mail.py` never read the `target_id` query parameter sent by the frontend. This means notification settings were always saved and loaded with `target_id=NULL`.

However, the real event dispatch path (`upsmon_client.py` → `multi_nut/notifications.py` → `EmailNotifier.send_notification`) correctly resolves the real bootstrapped target's id and queries notification settings scoped to that id. Since the settings were saved under `target_id=NULL` but queried under the real target id, the lookup always returned nothing — silently dropping every notification, including in the Test Center.

This affects installs regardless of single/multi-NUT profile, since a "Primary UPS" target row is always bootstrapped internally.

## Fix

Read the `target_id` query parameter in the affected routes and pass it through `_notification_scoped_query`, matching the pattern already used correctly by `/api/settings/test-notification` and other scoped routes.

## Additional fix bundled in this PR

`LogsSection.tsx` imports `./logs/useLogsSectionController`, but that file was never committed — not even in the original `v0.2.0` release commit — so the React frontend cannot build from source at all. Added the missing hook, implemented against the existing `/api/logs`, `/api/logs/clear`, `/api/logs/download`, `/api/settings/log`, and `/api/restart` endpoints, following the same conventions as the other settings section controllers (`mail`, `ntfy`, etc.).

## Testing

- Verified locally: `npm run build` in `nutify/frontend/app` now compiles and bundles successfully.
- Built and deployed a test image via GHCR; confirmed real ONBATT/ONLINE UPS events now trigger email notifications, and the Test Center in Notify settings now succeeds.
- Note for anyone upgrading: existing notification settings saved before this fix (under `target_id=NULL`) will need to be re-toggled/re-saved once in the Notify settings page so they get associated with the correct target scope.
