### PR TITLE
feat(auth): add generic OIDC single sign-on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+.pytest_cache/
+.ruff_cache/
+
+# Frontend build artifacts / dependencies
+node_modules/
+dist/
+.vite/
+
+# Local scratch / virtualenvs (never committed)
+.tmp/
+.venv/
+venv/

--- a/README.md
+++ b/README.md
@@ -167,6 +167,46 @@ The setup wizard allows you to configure:
 - Final configuration preview and controlled restart to apply generated NUT files
 
 
+## Single Sign-On (OIDC)
+
+Nutify supports optional OpenID Connect (OIDC) single sign-on with any spec-compliant
+provider (Authentik, Keycloak, Authelia, Zitadel, ...). SSO is **additive**: local
+username/password login keeps working and the primary administrator always remains a
+fallback. Users returned by the provider are auto-provisioned locally, and their Nutify
+role is derived from a configurable group claim.
+
+Register a confidential client at your provider with the redirect URI
+`https://<your-nutify-host>/auth/oidc/callback`, then set the following environment
+variables (see `docker-compose.yaml` for the full list):
+
+| Variable | Required | Description |
+| --- | --- | --- |
+| `OIDC_ENABLED` | yes | Enable SSO (`true`). |
+| `OIDC_ISSUER` | yes | Provider issuer URL (discovery base). |
+| `OIDC_CLIENT_ID` | yes | Registered client id. |
+| `OIDC_CLIENT_SECRET` | yes | Registered client secret. |
+| `OIDC_REDIRECT_URI` | no | Callback URL override when running behind a reverse proxy. |
+| `OIDC_SCOPES` | no | Requested scopes, default `openid profile email groups`. |
+| `OIDC_USERNAME_CLAIM` | no | Username claim, default `preferred_username` (falls back to `email`/`sub`). |
+| `OIDC_GROUPS_CLAIM` | no | Claim holding group membership, default `groups`. |
+| `OIDC_ADMIN_GROUP` | no | Group(s) mapped to the `administrator` role (comma-separated). |
+| `OIDC_USER_GROUP` | no | Optional group(s) mapped to the `user` role (comma-separated). See group mapping below. |
+| `OIDC_PROVIDER_NAME` / `OIDC_BUTTON_LABEL` | no | Login button display text. |
+
+**Group mapping.** A user's Nutify role is derived from their group claim (admin always
+wins):
+
+- Member of an `OIDC_ADMIN_GROUP` group → `administrator`.
+- Otherwise, if `OIDC_USER_GROUP` is **empty**, every authenticated user becomes a `user`.
+- If `OIDC_USER_GROUP` is **set**, it also gates access: only members of the admin or user
+  group may sign in, and everyone else is rejected.
+
+So the simplest setup is to configure just `OIDC_ADMIN_GROUP` (admins are admins, everyone
+else is a user). Add `OIDC_USER_GROUP` when you want to restrict who may sign in at all.
+
+Once enabled, a **Sign in with SSO** button appears on the login page.
+
+
 ## Tested UPS Models
 
 Nutify aims for broad compatibility with UPS devices supported by Network UPS Tools (NUT). 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ variables (see `docker-compose.yaml` for the full list):
 | `OIDC_ADMIN_GROUP` | no | Group(s) mapped to the `administrator` role (comma-separated). |
 | `OIDC_USER_GROUP` | no | Optional group(s) mapped to the `user` role (comma-separated). See group mapping below. |
 | `OIDC_PROVIDER_NAME` / `OIDC_BUTTON_LABEL` | no | Login button display text. |
+| `OIDC_AUTO_REDIRECT` | no | Skip the local form and send users straight to the provider (`true`). |
 
 **Group mapping.** A user's Nutify role is derived from their group claim (admin always
 wins):
@@ -205,6 +206,11 @@ So the simplest setup is to configure just `OIDC_ADMIN_GROUP` (admins are admins
 else is a user). Add `OIDC_USER_GROUP` when you want to restrict who may sign in at all.
 
 Once enabled, a **Sign in with SSO** button appears on the login page.
+
+With `OIDC_AUTO_REDIRECT=true` the login page forwards straight to the provider. The
+primary administrator (and anyone locked out by an unreachable provider) can still reach
+the local login form at **`/auth/login?local=1`** — this escape hatch is also linked from
+the redirect screen.
 
 
 ## Tested UPS Models

--- a/changelog.md
+++ b/changelog.md
@@ -12,6 +12,9 @@
 * **Reports And Notifications Scope Enhancements**
 * **Runtime And Service Hardening**
 * **Container And Build Pipeline Updates**
+* **OpenID Connect Single Sign-On (SSO)**: Optional, provider-agnostic OIDC login, additive to local authentication:
+  * Group-based role mapping via `OIDC_ADMIN_GROUP` and an optional `OIDC_USER_GROUP` that also gates who may sign in
+  * Optional `OIDC_AUTO_REDIRECT` to the provider, with a `/auth/login?local=1` escape hatch for the local administrator
 
 
 ## Version 0.1.7 (07/07/2025)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -36,6 +36,19 @@ services:
       - LOG_WERKZEUG=true                             # Enable Werkzeug HTTP/server logs: true or false, default is false
       - ENABLE_LOG_STARTUP=Y                          # Enable startup logs: valid values are Y or N, default is N, any other value is treated as N
       - SSL_ENABLED=false                             # true or false, default is false
+      # OIDC single sign-on (optional, additive to local login). Uncomment and fill in to enable.
+      # - OIDC_ENABLED=true                           # Enable OIDC SSO: 1/true/yes/on, default disabled
+      # - OIDC_ISSUER=https://sso.example.com/application/o/nutify/  # Provider issuer URL (discovery base)
+      # - OIDC_CLIENT_ID=nutify                       # Registered OIDC client id
+      # - OIDC_CLIENT_SECRET=change-me                # Registered OIDC client secret
+      # - OIDC_REDIRECT_URI=https://nutify.example.com/auth/oidc/callback  # Callback URL override (behind a proxy)
+      # - OIDC_SCOPES=openid profile email groups     # Requested scopes, default "openid profile email groups"
+      # - OIDC_USERNAME_CLAIM=preferred_username      # Username claim, default preferred_username (falls back to email/sub)
+      # - OIDC_GROUPS_CLAIM=groups                    # Claim holding group membership, default groups
+      # - OIDC_ADMIN_GROUP=nutify-admins              # Group(s) mapped to the administrator role (comma-separated)
+      # - OIDC_USER_GROUP=nutify-users                # Optional group(s) mapped to user; when set, only admin/user members may sign in
+      # - OIDC_PROVIDER_NAME=Authentik                # Display name used on the login button
+      # - OIDC_BUTTON_LABEL=Sign in with Authentik    # Explicit login button label override
      
      # DNS resolvers
     dns:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
       # - OIDC_USER_GROUP=nutify-users                # Optional group(s) mapped to user; when set, only admin/user members may sign in
       # - OIDC_PROVIDER_NAME=Authentik                # Display name used on the login button
       # - OIDC_BUTTON_LABEL=Sign in with Authentik    # Explicit login button label override
+      # - OIDC_AUTO_REDIRECT=true                     # Skip the local form; local login stays reachable at /auth/login?local=1
      
      # DNS resolvers
     dns:

--- a/nutify/app.py
+++ b/nutify/app.py
@@ -333,9 +333,11 @@ app.events_log = []
 try:
     from core.auth import setup_session_config
     from core.auth.security import init_auth_security
+    from core.auth.oidc import init_oidc_module
 
     setup_session_config(app)
     init_auth_security(app, logger)
+    init_oidc_module(app, logger)
 except Exception as auth_bootstrap_error:
     logger.warning(f"⚠️ Early auth security bootstrap failed: {auth_bootstrap_error}")
 
@@ -969,6 +971,7 @@ def init_app():
             try:
                 from core.auth import init_auth_module, setup_session_config
                 from core.auth.security import init_auth_security
+                from core.auth.oidc import init_oidc_module
                 
                 # Get LoginAuth model from database
                 if hasattr(db, 'ModelClasses') and hasattr(db.ModelClasses, 'LoginAuth'):
@@ -983,6 +986,7 @@ def init_app():
                     init_auth_module(login_model, logger)
                     setup_session_config(app)
                     init_auth_security(app, logger)
+                    init_oidc_module(app, logger)
                     logger.info("✅ Authentication system initialized successfully")
                 else:
                     logger.warning("⚠️ Authentication system initialization skipped - model not available")

--- a/nutify/core/auth/__init__.py
+++ b/nutify/core/auth/__init__.py
@@ -213,6 +213,40 @@ def login_user(username: str, password: str) -> bool:
         logger.warning(f"🔐 Failed login attempt for user: {username}")
     return False
 
+def login_oidc_user(username: str, role: str = 'user'):
+    """Provision and log in a user authenticated through OIDC SSO.
+
+    The user is created locally on first login (without a usable local
+    password) and its role is aligned with the provider group mapping on
+    every login. Local login and the primary admin fallback are unaffected.
+
+    Args:
+        username: Username reported by the identity provider.
+        role: Role derived from the provider group mapping.
+
+    Returns:
+        The provisioned LoginAuth user on success, otherwise None.
+    """
+    if not LoginAuth:
+        if logger:
+            logger.error("🔐 LoginAuth model not initialized")
+        return None
+
+    try:
+        user = LoginAuth.get_or_create_oidc_user(username, role)
+    except Exception as exc:
+        if logger:
+            logger.error(f"🔐 Failed to provision SSO user {username}: {str(exc)}")
+        return None
+
+    if flask_login_user is not None:
+        flask_login_user(user, remember=False)
+    _sync_session_from_user(user)
+
+    if logger:
+        logger.info(f"🔐 SSO user {username} logged in successfully")
+    return user
+
 def logout_user() -> None:
     """Logout the current user by clearing the session."""
     username = session.get('username', 'unknown')

--- a/nutify/core/auth/oidc.py
+++ b/nutify/core/auth/oidc.py
@@ -27,6 +27,9 @@ Configuration is entirely environment driven:
                           authenticated user who is not an admin becomes a user.
     OIDC_PROVIDER_NAME    Display name used on the login button.
     OIDC_BUTTON_LABEL     Explicit login button label override.
+    OIDC_AUTO_REDIRECT    Send users straight to the provider, skipping the local
+                          login form. The primary admin can still reach the local
+                          form via ``/auth/login?local=1``.
 """
 
 from __future__ import annotations
@@ -114,6 +117,15 @@ def is_oidc_enabled() -> bool:
     return bool(OAuth) and _get_env_flag('OIDC_ENABLED') and is_oidc_configured()
 
 
+def is_auto_redirect() -> bool:
+    """Check whether the login page should jump straight to the provider.
+
+    Only meaningful when SSO is actually usable; the ``?local=1`` escape hatch
+    always lets the primary admin reach the local login form regardless.
+    """
+    return is_oidc_enabled() and _get_env_flag('OIDC_AUTO_REDIRECT')
+
+
 def get_public_config() -> Dict[str, Any]:
     """Return SSO details that are safe to expose to the frontend.
 
@@ -124,6 +136,7 @@ def get_public_config() -> Dict[str, Any]:
     button_label = _get_env('OIDC_BUTTON_LABEL') or f'Sign in with {provider_name}'
     return {
         'enabled': enabled,
+        'auto_redirect': enabled and is_auto_redirect(),
         'login_url': '/auth/oidc/login',
         'provider_name': provider_name,
         'button_label': button_label,

--- a/nutify/core/auth/oidc.py
+++ b/nutify/core/auth/oidc.py
@@ -1,0 +1,312 @@
+"""OpenID Connect (OIDC) single sign-on for Nutify.
+
+This module adds a generic, provider-agnostic OIDC Authorization Code flow on
+top of the existing local username/password login. It works with any spec
+compliant provider (Authentik, Keycloak, Authelia, Zitadel, ...) discovered via
+the ``.well-known/openid-configuration`` document.
+
+SSO is strictly additive: local login keeps working and the primary admin
+(user id 1) always remains a fallback. Users returned by the provider are
+auto-provisioned locally, and their Nutify role is derived from a configurable
+group claim (group -> role mapping).
+
+Configuration is entirely environment driven:
+
+    OIDC_ENABLED          Enable the SSO flow (1/true/yes/on).
+    OIDC_ISSUER           Provider issuer URL (discovery base).
+    OIDC_CLIENT_ID        Registered client id.
+    OIDC_CLIENT_SECRET    Registered client secret.
+    OIDC_SCOPES           Requested scopes (default: "openid profile email groups").
+    OIDC_REDIRECT_URI     Explicit callback URL override (behind a proxy).
+    OIDC_USERNAME_CLAIM   Preferred username claim (default: preferred_username).
+    OIDC_GROUPS_CLAIM     Claim holding group membership (default: groups).
+    OIDC_ADMIN_GROUP      Group(s) mapped to the administrator role (comma-separated).
+    OIDC_USER_GROUP       Optional group(s) mapped to the user role (comma-separated).
+                          When set, only members of the admin or user group may sign
+                          in (everyone else is rejected). When left empty, every
+                          authenticated user who is not an admin becomes a user.
+    OIDC_PROVIDER_NAME    Display name used on the login button.
+    OIDC_BUTTON_LABEL     Explicit login button label override.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from flask import url_for
+
+try:
+    from authlib.integrations.flask_client import OAuth
+except Exception:  # pragma: no cover - optional dependency guard
+    OAuth = None
+
+
+# These will be set during initialization
+logger = None
+_oauth = None
+_registered = False
+
+# Internal name of the registered Authlib client.
+OIDC_CLIENT_NAME = 'nutify_oidc'
+
+DEFAULT_SCOPES = 'openid profile email groups'
+DEFAULT_USERNAME_CLAIM = 'preferred_username'
+DEFAULT_GROUPS_CLAIM = 'groups'
+DEFAULT_ROLE = 'user'
+ADMIN_ROLE = 'administrator'
+
+
+class OidcError(Exception):
+    """Raised when an OIDC login cannot be completed."""
+
+
+def _get_env(name: str, default: str = '') -> str:
+    """Return a trimmed environment variable value."""
+    return os.getenv(name, default).strip()
+
+
+def _get_env_flag(name: str) -> bool:
+    """Check if an environment variable is set to a truthy value."""
+    value = os.getenv(name, '').strip().lower()
+    return value in {'1', 'true', 'yes', 'on'}
+
+
+def _get_scopes() -> str:
+    """Return the requested OAuth scopes, always including ``openid``."""
+    scopes = _get_env('OIDC_SCOPES', DEFAULT_SCOPES) or DEFAULT_SCOPES
+    parts = [part for part in scopes.replace(',', ' ').split() if part]
+    if 'openid' not in parts:
+        parts.insert(0, 'openid')
+    return ' '.join(parts)
+
+
+def _split_groups(raw: str) -> List[str]:
+    """Split a comma-separated group list into lowercase names."""
+    return [group.strip().lower() for group in raw.split(',') if group.strip()]
+
+
+def _get_admin_groups() -> List[str]:
+    """Return the groups mapped to the administrator role (case-insensitive)."""
+    return _split_groups(_get_env('OIDC_ADMIN_GROUP'))
+
+
+def _get_user_groups() -> List[str]:
+    """Return the groups mapped to the user role (case-insensitive).
+
+    Empty by default. When configured, it also gates access: users who are in
+    neither the admin nor the user group are rejected.
+    """
+    return _split_groups(_get_env('OIDC_USER_GROUP'))
+
+
+def is_oidc_configured() -> bool:
+    """Check whether the mandatory OIDC settings are present."""
+    return bool(
+        _get_env('OIDC_ISSUER')
+        and _get_env('OIDC_CLIENT_ID')
+        and _get_env('OIDC_CLIENT_SECRET')
+    )
+
+
+def is_oidc_enabled() -> bool:
+    """Check whether OIDC SSO is enabled, configured and usable."""
+    return bool(OAuth) and _get_env_flag('OIDC_ENABLED') and is_oidc_configured()
+
+
+def get_public_config() -> Dict[str, Any]:
+    """Return SSO details that are safe to expose to the frontend.
+
+    Never includes the client secret or issuer internals.
+    """
+    enabled = is_oidc_enabled()
+    provider_name = _get_env('OIDC_PROVIDER_NAME', 'SSO') or 'SSO'
+    button_label = _get_env('OIDC_BUTTON_LABEL') or f'Sign in with {provider_name}'
+    return {
+        'enabled': enabled,
+        'login_url': '/auth/oidc/login',
+        'provider_name': provider_name,
+        'button_label': button_label,
+    }
+
+
+def init_oidc_module(app, oidc_logger=None) -> None:
+    """Initialize the OIDC module and register the provider client.
+
+    Registration is lazy about network access: Authlib only fetches the
+    provider metadata on the first login attempt, so a down provider never
+    blocks application startup.
+
+    Args:
+        app: Flask application instance.
+        oidc_logger: Logger instance for authentication operations.
+    """
+    global _oauth, _registered, logger
+    logger = oidc_logger
+
+    if app.extensions.get('nutify_oidc_initialized'):
+        return
+
+    if OAuth is None:
+        if logger:
+            logger.warning("🔐 OIDC SSO unavailable (authlib not installed)")
+        return
+
+    if not is_oidc_enabled():
+        if logger:
+            logger.info("🔐 OIDC SSO disabled (set OIDC_ENABLED and issuer/client config to enable)")
+        return
+
+    issuer = _get_env('OIDC_ISSUER').rstrip('/')
+    _oauth = OAuth(app)
+    _oauth.register(
+        name=OIDC_CLIENT_NAME,
+        client_id=_get_env('OIDC_CLIENT_ID'),
+        client_secret=_get_env('OIDC_CLIENT_SECRET'),
+        server_metadata_url=f'{issuer}/.well-known/openid-configuration',
+        client_kwargs={'scope': _get_scopes()},
+    )
+    _registered = True
+    app.extensions['nutify_oidc_initialized'] = True
+
+    if logger:
+        logger.info(f"🔐 OIDC SSO initialized (issuer: {issuer})")
+
+
+def _get_client():
+    """Return the registered Authlib client or raise if SSO is not ready."""
+    if not _oauth or not _registered:
+        raise OidcError('OIDC SSO is not initialized')
+    client = _oauth.create_client(OIDC_CLIENT_NAME)
+    if client is None:
+        raise OidcError('OIDC client is not registered')
+    return client
+
+
+def _resolve_redirect_uri() -> str:
+    """Resolve the callback URL, honoring an explicit proxy override."""
+    override = _get_env('OIDC_REDIRECT_URI')
+    if override:
+        return override
+    return url_for('auth.oidc_callback', _external=True)
+
+
+def begin_login():
+    """Start the Authorization Code flow by redirecting to the provider."""
+    if not is_oidc_enabled():
+        raise OidcError('OIDC SSO is not enabled')
+    client = _get_client()
+    redirect_uri = _resolve_redirect_uri()
+    if logger:
+        logger.info(f"🔐 Starting OIDC login (redirect_uri: {redirect_uri})")
+    return client.authorize_redirect(redirect_uri)
+
+
+def _extract_username(claims: Dict[str, Any]) -> str:
+    """Pick a username from the token claims using a configurable priority."""
+    preferred = _get_env('OIDC_USERNAME_CLAIM', DEFAULT_USERNAME_CLAIM) or DEFAULT_USERNAME_CLAIM
+    for key in (preferred, 'preferred_username', 'email', 'sub'):
+        value = claims.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return ''
+
+
+def _extract_groups(claims: Dict[str, Any]) -> List[str]:
+    """Normalize the group claim into a list of strings."""
+    groups_claim = _get_env('OIDC_GROUPS_CLAIM', DEFAULT_GROUPS_CLAIM) or DEFAULT_GROUPS_CLAIM
+    raw = claims.get(groups_claim)
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        return [part.strip() for part in raw.replace(',', ' ').split() if part.strip()]
+    if isinstance(raw, (list, tuple, set)):
+        return [str(item).strip() for item in raw if str(item).strip()]
+    return []
+
+
+def resolve_role(groups: List[str]) -> Optional[str]:
+    """Map provider groups to a Nutify role.
+
+    Rules (admin always wins):
+        * member of an admin group          -> ``administrator``
+        * member of a user group            -> ``user``
+        * no user group configured          -> ``user`` (everyone is let in)
+        * user group configured, no match   -> ``None`` (access rejected)
+
+    Returns:
+        The resolved role, or ``None`` when the user is not a member of any
+        authorized group and must be rejected.
+    """
+    member_of = {group.lower() for group in groups}
+    if set(_get_admin_groups()) & member_of:
+        return ADMIN_ROLE
+
+    user_groups = set(_get_user_groups())
+    if not user_groups:
+        # No user group configured: every authenticated user becomes a user.
+        return DEFAULT_ROLE
+    if user_groups & member_of:
+        return DEFAULT_ROLE
+    # A user group is configured but the user is in none of the allowed groups.
+    return None
+
+
+def _merge_userinfo(client, token: Dict[str, Any]) -> Dict[str, Any]:
+    """Combine id_token claims with the userinfo endpoint (best effort).
+
+    Some providers only expose group membership from the userinfo endpoint,
+    so we enrich the id_token claims when possible without failing the login.
+    """
+    claims: Dict[str, Any] = dict(token.get('userinfo') or {})
+    try:
+        endpoint_claims = client.userinfo(token=token)
+        if endpoint_claims:
+            claims.update(dict(endpoint_claims))
+    except Exception as exc:  # pragma: no cover - provider dependent
+        if logger:
+            logger.debug(f"🔐 OIDC userinfo endpoint not used: {str(exc)}")
+    return claims
+
+
+def complete_login() -> Dict[str, Any]:
+    """Finish the callback: exchange the code and resolve the SSO identity.
+
+    Returns:
+        dict: ``{'username': str, 'role': str, 'groups': list}``.
+
+    Raises:
+        OidcError: If the flow fails or no username claim is present.
+    """
+    if not is_oidc_enabled():
+        raise OidcError('OIDC SSO is not enabled')
+
+    client = _get_client()
+    try:
+        token = client.authorize_access_token()
+    except Exception as exc:
+        if logger:
+            logger.warning(f"🔐 OIDC token exchange failed: {str(exc)}")
+        raise OidcError('OIDC token exchange failed') from exc
+
+    claims = _merge_userinfo(client, token)
+    username = _extract_username(claims)
+    if not username:
+        if logger:
+            logger.warning("🔐 OIDC login rejected: no usable username claim")
+        raise OidcError('No username claim returned by the provider')
+
+    groups = _extract_groups(claims)
+    role = resolve_role(groups)
+    if role is None:
+        if logger:
+            logger.warning(
+                f"🔐 OIDC login rejected: user '{username}' is not a member of "
+                f"any authorized group"
+            )
+        raise OidcError('User is not a member of an authorized group')
+
+    if logger:
+        logger.info(f"🔐 OIDC login resolved user '{username}' to role '{role}'")
+
+    return {'username': username, 'role': role, 'groups': groups}

--- a/nutify/core/auth/routes.py
+++ b/nutify/core/auth/routes.py
@@ -27,6 +27,22 @@ from core.logger import web_logger as logger
 # Create blueprint
 auth_bp = Blueprint('auth', __name__, url_prefix='/auth')
 
+# Query-string flag that lets the primary admin reach the local login form even
+# when SSO auto-redirect is enabled, e.g. /auth/login?local=1
+LOCAL_LOGIN_PARAM = 'local'
+_TRUTHY_VALUES = {'1', 'true', 'yes', 'on'}
+
+
+def _wants_local_login() -> bool:
+    """Return True when the request explicitly asks for the local login form."""
+    return request.args.get(LOCAL_LOGIN_PARAM, '').strip().lower() in _TRUTHY_VALUES
+
+
+def _local_login_url() -> str:
+    """Local login URL with the SSO auto-redirect suppressed (loop-safe)."""
+    return url_for('auth.login', **{LOCAL_LOGIN_PARAM: 1})
+
+
 @auth_bp.route('/login', methods=['GET', 'POST'])
 @rate_limit('10 per minute', methods=['POST'])
 def login():
@@ -40,7 +56,13 @@ def login():
     # If already authenticated, redirect to main page
     if is_authenticated():
         return redirect(url_for('index'))
-    
+
+    # Optionally send users straight to the SSO provider, unless they explicitly
+    # requested the local login form (?local=1) — the documented escape hatch for
+    # the primary administrator and for when the provider is unreachable.
+    if request.method == 'GET' and oidc.is_auto_redirect() and not _wants_local_login():
+        return redirect(url_for('auth.oidc_login'))
+
     if request.method == 'POST':
         username = request.form.get('username', '').strip()
         password = request.form.get('password', '')
@@ -78,14 +100,14 @@ def oidc_login():
         return redirect(url_for('index'))
     if not oidc.is_oidc_enabled():
         flash('Single sign-on is not enabled', 'error')
-        return redirect(url_for('auth.login'))
+        return redirect(_local_login_url())
 
     try:
         return oidc.begin_login()
     except oidc.OidcError as exc:
         logger.error(f"🔐 OIDC login could not be started: {str(exc)}")
         flash('Single sign-on is currently unavailable', 'error')
-        return redirect(url_for('auth.login'))
+        return redirect(_local_login_url())
 
 @auth_bp.route('/oidc/callback')
 @rate_limit('20 per minute')
@@ -95,19 +117,19 @@ def oidc_callback():
         return redirect(url_for('index'))
     if not oidc.is_oidc_enabled():
         flash('Single sign-on is not enabled', 'error')
-        return redirect(url_for('auth.login'))
+        return redirect(_local_login_url())
 
     try:
         identity = oidc.complete_login()
     except oidc.OidcError as exc:
         logger.warning(f"🔐 OIDC callback failed: {str(exc)}")
         flash('Single sign-on failed. Please try again.', 'error')
-        return redirect(url_for('auth.login'))
+        return redirect(_local_login_url())
 
     user = login_oidc_user(identity['username'], identity['role'])
     if not user:
         flash('Could not provision your single sign-on account', 'error')
-        return redirect(url_for('auth.login'))
+        return redirect(_local_login_url())
 
     logger.info(f"🔐 Successful SSO login for user: {identity['username']}")
     return redirect(url_for('index'))

--- a/nutify/core/auth/routes.py
+++ b/nutify/core/auth/routes.py
@@ -8,6 +8,7 @@ initial setup, and admin panel.
 from flask import Blueprint, request, redirect, url_for, flash, jsonify, current_app
 from . import (
     login_user,
+    login_oidc_user,
     logout_user,
     is_authenticated,
     get_current_user,
@@ -17,6 +18,7 @@ from . import (
     require_admin
 )
 from .security import rate_limit
+from . import oidc
 from core.react_frontend import serve_react_index
 from datetime import datetime
 import pytz
@@ -65,6 +67,55 @@ def logout():
     logout_user()
     flash('You have been logged out', 'success')
     return redirect(url_for('auth.login'))
+
+@auth_bp.route('/oidc/login')
+@rate_limit('20 per minute')
+def oidc_login():
+    """Start the OIDC single sign-on flow by redirecting to the provider."""
+    if is_auth_disabled():
+        return redirect(url_for('index'))
+    if is_authenticated():
+        return redirect(url_for('index'))
+    if not oidc.is_oidc_enabled():
+        flash('Single sign-on is not enabled', 'error')
+        return redirect(url_for('auth.login'))
+
+    try:
+        return oidc.begin_login()
+    except oidc.OidcError as exc:
+        logger.error(f"🔐 OIDC login could not be started: {str(exc)}")
+        flash('Single sign-on is currently unavailable', 'error')
+        return redirect(url_for('auth.login'))
+
+@auth_bp.route('/oidc/callback')
+@rate_limit('20 per minute')
+def oidc_callback():
+    """Handle the OIDC provider redirect and establish the local session."""
+    if is_auth_disabled():
+        return redirect(url_for('index'))
+    if not oidc.is_oidc_enabled():
+        flash('Single sign-on is not enabled', 'error')
+        return redirect(url_for('auth.login'))
+
+    try:
+        identity = oidc.complete_login()
+    except oidc.OidcError as exc:
+        logger.warning(f"🔐 OIDC callback failed: {str(exc)}")
+        flash('Single sign-on failed. Please try again.', 'error')
+        return redirect(url_for('auth.login'))
+
+    user = login_oidc_user(identity['username'], identity['role'])
+    if not user:
+        flash('Could not provision your single sign-on account', 'error')
+        return redirect(url_for('auth.login'))
+
+    logger.info(f"🔐 Successful SSO login for user: {identity['username']}")
+    return redirect(url_for('index'))
+
+@auth_bp.route('/api/oidc')
+def api_oidc_config():
+    """Public endpoint exposing SSO availability for the login page."""
+    return jsonify(oidc.get_public_config())
 
 @auth_bp.route('/setup', methods=['GET', 'POST'])
 @rate_limit('5 per hour', methods=['POST'])

--- a/nutify/core/db/orm/orm_ups_login.py
+++ b/nutify/core/db/orm/orm_ups_login.py
@@ -6,6 +6,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 from typing import Optional, Dict, Any
 import pytz
 import json
+import secrets
 from flask import current_app
 
 # These will be set during initialization
@@ -64,8 +65,23 @@ class LoginAuth:
         if logger:
             logger.debug(f"🔐 Password hash set for username: {self.username}")
 
+    def set_unusable_password(self) -> None:
+        """Set a password hash that can never match (SSO-only accounts).
+
+        SSO users authenticate through the identity provider and must not be
+        able to log in locally, so we store a random, non-verifiable marker.
+        """
+        self.password_hash = f'!oidc:{secrets.token_urlsafe(32)}'
+        if logger:
+            logger.debug(f"🔐 Set unusable (SSO-only) password for username: {self.username}")
+
     def check_password(self, password: str) -> bool:
         """Check if provided password matches the stored hash"""
+        # SSO-only accounts carry a non-verifiable marker instead of a real hash.
+        if not self.password_hash or self.password_hash.startswith('!'):
+            if logger:
+                logger.debug(f"🔐 Password check for SSO-only username {self.username}: ❌ FAILED (no local password)")
+            return False
         result = check_password_hash(self.password_hash, password)
         if logger:
             logger.debug(f"🔐 Password check for username {self.username}: {'✅ SUCCESS' if result else '❌ FAILED'}")
@@ -267,6 +283,67 @@ class LoginAuth:
             db.session.rollback()
             if logger:
                 logger.error(f"🔐 Error creating user {username}: {str(e)}")
+            raise
+
+    @classmethod
+    def get_or_create_oidc_user(cls, username: str, role: str = 'user') -> 'LoginAuth':
+        """Provision (or update) a user authenticated via OIDC SSO.
+
+        New users are created without a usable local password. Existing users
+        are reactivated and their role is aligned with the group mapping on
+        every login. The primary administrator (id 1) is never modified, so
+        the local admin always stays a fallback.
+
+        Args:
+            username: Username reported by the identity provider.
+            role: Role derived from the provider group mapping.
+
+        Returns:
+            LoginAuth: The provisioned or updated user instance.
+        """
+        from core.db.ups import db
+
+        role = role if role in ('administrator', 'user') else 'user'
+        user = cls.query.filter_by(username=username).first()
+
+        if user:
+            # Never let SSO change the primary admin fallback account.
+            if user.id != 1:
+                if not user.is_active:
+                    user.is_active = True
+                if user.role != role:
+                    user.role = role
+                    user.is_admin = (role == 'administrator')
+                    user.set_permissions(user.get_default_permissions())
+                    user.set_options_tabs(user.get_default_options_tabs())
+                    if logger:
+                        logger.info(f"🔐 Updated SSO user {username} to role: {role}")
+            user.update_last_login()
+            try:
+                db.session.commit()
+                return user
+            except Exception as e:
+                db.session.rollback()
+                if logger:
+                    logger.error(f"🔐 Error updating SSO user {username}: {str(e)}")
+                raise
+
+        user = cls(username=username, role=role, is_admin=(role == 'administrator'), is_active=True)
+        user.set_unusable_password()
+        user.set_permissions(user.get_default_permissions())
+        user.set_options_tabs(user.get_default_options_tabs())
+        user.update_last_login()
+
+        try:
+            db.session.add(user)
+            db.session.commit()
+            if logger:
+                logger.info(f"🔐 Provisioned new SSO user: {username} with role: {role}")
+            return user
+        except Exception as e:
+            db.session.rollback()
+            if logger:
+                logger.error(f"🔐 Error provisioning SSO user {username}: {str(e)}")
             raise
 
     @classmethod

--- a/nutify/docker-compose.yaml
+++ b/nutify/docker-compose.yaml
@@ -49,6 +49,7 @@ services:
       # - OIDC_USER_GROUP=nutify-users           # Optional group(s) mapped to user; when set, only admin/user members may sign in
       # - OIDC_PROVIDER_NAME=Authentik           # Display name used on the login button
       # - OIDC_BUTTON_LABEL=Sign in with Authentik  # Explicit login button label override
+      # - OIDC_AUTO_REDIRECT=true                # Skip the local form; local login stays reachable at /auth/login?local=1
      
      # DNS resolvers
     dns:

--- a/nutify/docker-compose.yaml
+++ b/nutify/docker-compose.yaml
@@ -36,6 +36,19 @@ services:
       - LOG_WERKZEUG=true                        # Enable Werkzeug HTTP/server logs: true or false, default is false
       - ENABLE_LOG_STARTUP=Y                     # Valid values are Y or N, default is N, any other value is treated as N
       - SSL_ENABLED=false                        # true or false, default is false
+      # OIDC single sign-on (optional, additive to local login). Uncomment and fill in to enable.
+      # - OIDC_ENABLED=true                      # Enable OIDC SSO: 1/true/yes/on, default disabled
+      # - OIDC_ISSUER=https://sso.example.com/application/o/nutify/  # Provider issuer URL (discovery base)
+      # - OIDC_CLIENT_ID=nutify                  # Registered OIDC client id
+      # - OIDC_CLIENT_SECRET=change-me           # Registered OIDC client secret
+      # - OIDC_REDIRECT_URI=https://nutify.example.com/auth/oidc/callback  # Callback URL override (behind a proxy)
+      # - OIDC_SCOPES=openid profile email groups  # Requested scopes, default "openid profile email groups"
+      # - OIDC_USERNAME_CLAIM=preferred_username # Username claim, default preferred_username (falls back to email/sub)
+      # - OIDC_GROUPS_CLAIM=groups               # Claim holding group membership, default groups
+      # - OIDC_ADMIN_GROUP=nutify-admins         # Group(s) mapped to the administrator role (comma-separated)
+      # - OIDC_USER_GROUP=nutify-users           # Optional group(s) mapped to user; when set, only admin/user members may sign in
+      # - OIDC_PROVIDER_NAME=Authentik           # Display name used on the login button
+      # - OIDC_BUTTON_LABEL=Sign in with Authentik  # Explicit login button label override
      
      # DNS resolvers
     dns:

--- a/nutify/frontend/app/src/features/auth/LoginPage.tsx
+++ b/nutify/frontend/app/src/features/auth/LoginPage.tsx
@@ -6,15 +6,23 @@
 
 import { useEffect, useState } from 'react'
 import type { FormEvent } from 'react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useSearchParams } from 'react-router-dom'
 
 import { getOidcConfig, login } from '../../lib/api/auth'
 import type { OidcConfig } from '../../lib/api/auth'
 
 const SETUP_LOGO_SRC = `${import.meta.env.BASE_URL}Nutify-Logo.png`
 
+// Escape hatch to reach the local login form when SSO auto-redirect is enabled.
+const LOCAL_LOGIN_HREF = '/auth/login?local=1'
+const LOCAL_LOGIN_VALUES = new Set(['1', 'true', 'yes', 'on'])
+
 export function LoginPage() {
   const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const forceLocalLogin = LOCAL_LOGIN_VALUES.has(
+    (searchParams.get('local') ?? '').trim().toLowerCase(),
+  )
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
@@ -33,6 +41,17 @@ export function LoginPage() {
     }
   }, [])
 
+  // Send the user straight to the provider when auto-redirect is on, unless they
+  // explicitly asked for the local login form (?local=1). ``replace`` keeps the
+  // redirect out of history so the back button cannot bounce into a loop.
+  const autoRedirecting = Boolean(oidc?.enabled && oidc.auto_redirect && !forceLocalLogin)
+
+  useEffect(() => {
+    if (autoRedirecting && oidc) {
+      window.location.replace(oidc.login_url)
+    }
+  }, [autoRedirecting, oidc])
+
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     setPending(true)
@@ -48,6 +67,40 @@ export function LoginPage() {
     } finally {
       setPending(false)
     }
+  }
+
+  if (autoRedirecting && oidc) {
+    return (
+      <div className="setup-container">
+        <div className="setup-header">
+          <img src={SETUP_LOGO_SRC} alt="Nutify Logo" className="setup-logo" />
+          <h1 className="setup-title">Nutify Login</h1>
+          <div className="setup-intro">
+            <p>UPS Monitoring System</p>
+          </div>
+        </div>
+
+        <div className="setup-card">
+          <div className="card-heading">
+            <i className="fas fa-right-to-bracket" />
+            <h2>Signing you in</h2>
+          </div>
+          <div className="card-content">
+            <p>Redirecting to {oidc.provider_name}…</p>
+            <div className="wizard-actions">
+              <a className="nav-btn next-btn" href={oidc.login_url}>
+                <i className="fas fa-right-to-bracket" /> {oidc.button_label}
+              </a>
+            </div>
+            <div className="setup-intro">
+              <p>
+                <a href={LOCAL_LOGIN_HREF}>Use local administrator login</a>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    )
   }
 
   return (

--- a/nutify/frontend/app/src/features/auth/LoginPage.tsx
+++ b/nutify/frontend/app/src/features/auth/LoginPage.tsx
@@ -4,11 +4,12 @@
  * Frontend module used by Nutify React UI flows and state management.
  */
 
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import type { FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 
-import { login } from '../../lib/api/auth'
+import { getOidcConfig, login } from '../../lib/api/auth'
+import type { OidcConfig } from '../../lib/api/auth'
 
 const SETUP_LOGO_SRC = `${import.meta.env.BASE_URL}Nutify-Logo.png`
 
@@ -18,6 +19,19 @@ export function LoginPage() {
   const [password, setPassword] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [pending, setPending] = useState(false)
+  const [oidc, setOidc] = useState<OidcConfig | null>(null)
+
+  useEffect(() => {
+    let active = true
+    void getOidcConfig().then((config) => {
+      if (active) {
+        setOidc(config)
+      }
+    })
+    return () => {
+      active = false
+    }
+  }, [])
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault()
@@ -96,6 +110,14 @@ export function LoginPage() {
               </button>
             </div>
           </form>
+
+          {oidc?.enabled ? (
+            <div className="wizard-actions">
+              <a className="nav-btn prev-btn" href={oidc.login_url}>
+                <i className="fas fa-right-to-bracket" /> {oidc.button_label}
+              </a>
+            </div>
+          ) : null}
         </div>
       </div>
     </div>

--- a/nutify/frontend/app/src/features/settings/sections/logs/useLogsSectionController.ts
+++ b/nutify/frontend/app/src/features/settings/sections/logs/useLogsSectionController.ts
@@ -1,0 +1,401 @@
+/**
+ * Uselogssectioncontroller.
+ *
+ * Frontend module used by Nutify React UI flows and state management.
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+
+import {
+  clearLogs,
+  getLogSettings,
+  getLogs,
+  getLogsDownloadUrl,
+  saveLogSettings,
+} from '../../../../lib/api/settings'
+
+type AlertTone = 'success' | 'danger'
+
+type StatusAlert = {
+  message: string
+  tone: AlertTone
+} | null
+
+type LogSettings = {
+  log: boolean
+  level: string
+  werkzeug: boolean
+}
+
+type LogLine = {
+  content: string
+  file: string
+  line_number: number
+  level?: string
+}
+
+type NormalizedLogs = {
+  lines: LogLine[]
+  total_files: number
+  total_size: number
+  has_more: boolean
+}
+
+const DEFAULT_LOG_SETTINGS: LogSettings = {
+  log: true,
+  level: 'INFO',
+  werkzeug: false,
+}
+
+function notifyUser(message: string, tone: 'success' | 'error' | 'info'): void {
+  const unsafeWindow = window as unknown as {
+    notify?: (text: string, level: string, timeout?: number) => void
+  }
+  if (typeof unsafeWindow.notify === 'function') {
+    unsafeWindow.notify(message, tone, 5000)
+  }
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes <= 0) {
+    return '0 Bytes'
+  }
+  const units = ['Bytes', 'KB', 'MB', 'GB']
+  const exponent = Math.floor(Math.log(bytes) / Math.log(1024))
+  return `${(bytes / 1024 ** exponent).toFixed(2)} ${units[exponent]}`
+}
+
+function normalizeLogSettings(payload: unknown): LogSettings {
+  if (!payload || typeof payload !== 'object') {
+    return { ...DEFAULT_LOG_SETTINGS }
+  }
+  const data = (payload as { data?: unknown }).data
+  if (!data || typeof data !== 'object') {
+    return { ...DEFAULT_LOG_SETTINGS }
+  }
+  const row = data as Record<string, unknown>
+  return {
+    log: Boolean(row.log),
+    level: String(row.level ?? 'INFO'),
+    werkzeug: Boolean(row.werkzeug),
+  }
+}
+
+function normalizeLogs(payload: unknown): NormalizedLogs {
+  const empty: NormalizedLogs = { lines: [], total_files: 0, total_size: 0, has_more: false }
+  if (!payload || typeof payload !== 'object') {
+    return empty
+  }
+  const data = (payload as { data?: unknown }).data
+  if (!data || typeof data !== 'object') {
+    return empty
+  }
+  const row = data as Record<string, unknown>
+  return {
+    lines: (Array.isArray(row.lines) ? row.lines : [])
+      .map((entry) => {
+        if (!entry || typeof entry !== 'object') {
+          return null
+        }
+        const raw = entry as Record<string, unknown>
+        const line: LogLine = {
+          content: String(raw.content ?? ''),
+          file: String(raw.file ?? ''),
+          line_number: Number(raw.line_number ?? 0),
+        }
+        if (raw.level !== undefined && raw.level !== null) {
+          line.level = String(raw.level)
+        }
+        return line
+      })
+      .filter((line): line is LogLine => line !== null),
+    total_files: Number(row.total_files ?? 0),
+    total_size: Number(row.total_size ?? 0),
+    has_more: Boolean(row.has_more),
+  }
+}
+
+function renderLogLine(line: LogLine): string {
+  const levelMatch = line.content.match(/\[(DEBUG|INFO|WARNING|ERROR)\]/i)
+  const levelClass = levelMatch
+    ? `log-${levelMatch[1].toLowerCase()}`
+    : line.level
+      ? `log-${line.level.toLowerCase()}`
+      : ''
+  const timestampMatch = line.content.match(
+    /^(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Z+-]\d{2}:?\d{2})?)/,
+  )
+  const timestamp = timestampMatch ? timestampMatch[1] : ''
+  const content = timestamp ? line.content.substring(timestamp.length).trim() : line.content
+  return `<div class="log-line ${levelClass}">
+    <span class="log-file">${escapeHtml(line.file)}</span>
+    <span class="log-number">#${escapeHtml(String(line.line_number))}</span>
+    ${timestamp ? `<span class="log-timestamp">${escapeHtml(timestamp)}</span>` : ''}
+    <span class="log-content">${escapeHtml(content)}</span>
+  </div>`
+}
+
+export function useLogsSectionController() {
+  const previewRef = useRef<HTMLPreElement | null>(null)
+  const pageRef = useRef(1)
+  const loadingRef = useRef(false)
+
+  const [alert, setAlert] = useState<StatusAlert>(null)
+  const [logType, setLogType] = useState('all')
+  const [logLevel, setLogLevel] = useState('all')
+  const [dateRange, setDateRange] = useState('today')
+  const [logSettings, setLogSettings] = useState<LogSettings>(DEFAULT_LOG_SETTINGS)
+  const [javascriptLogsEnabled, setJavascriptLogsEnabled] = useState(true)
+  const [hasMoreLogs, setHasMoreLogs] = useState(false)
+  const [isLoadingLogs, setIsLoadingLogs] = useState(false)
+  const [logsLoaded, setLogsLoaded] = useState(false)
+  const [previewHtml, setPreviewHtml] = useState('')
+  const [logCountText, setLogCountText] = useState('Found 0 log files')
+  const [refreshBusy, setRefreshBusy] = useState(false)
+  const [downloadBusy, setDownloadBusy] = useState(false)
+  const [clearBusy, setClearBusy] = useState(false)
+  const [saveBusy, setSaveBusy] = useState(false)
+
+  const showAlert = useCallback((message: string, tone: AlertTone) => {
+    setAlert({ message, tone })
+    notifyUser(message, tone === 'danger' ? 'error' : 'success')
+  }, [])
+
+  const logQuery = useMemo(
+    () => ({ type: logType, level: logLevel, range: dateRange }),
+    [dateRange, logLevel, logType],
+  )
+
+  const loadLogs = useCallback(
+    async (reset: boolean) => {
+      if (loadingRef.current) {
+        return
+      }
+      loadingRef.current = true
+      setIsLoadingLogs(true)
+      setRefreshBusy(true)
+      try {
+        const page = reset ? 1 : pageRef.current
+        const normalized = normalizeLogs(await getLogs({ ...logQuery, page, page_size: 1000 }))
+        const html = normalized.lines.map(renderLogLine).join('')
+        setLogsLoaded(true)
+        setLogCountText(`Found ${normalized.total_files} log files (${formatBytes(normalized.total_size)})`)
+        setHasMoreLogs(normalized.has_more)
+        if (reset) {
+          pageRef.current = 1
+          setPreviewHtml(html)
+        } else {
+          setPreviewHtml((prev) => `${prev}${html}`)
+        }
+        if (!html && reset) {
+          setPreviewHtml('No logs found for selected filters')
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : 'Error loading logs'
+        showAlert(message, 'danger')
+        if (reset) {
+          setPreviewHtml('Error loading logs. Please try again.')
+          setLogCountText('Found 0 log files')
+        }
+      } finally {
+        loadingRef.current = false
+        setIsLoadingLogs(false)
+        setRefreshBusy(false)
+      }
+    },
+    [logQuery, showAlert],
+  )
+
+  const loadMoreLogs = useCallback(async () => {
+    if (loadingRef.current || !hasMoreLogs) {
+      return
+    }
+    loadingRef.current = true
+    const nextPage = pageRef.current + 1
+    pageRef.current = nextPage
+    setIsLoadingLogs(true)
+    try {
+      const normalized = normalizeLogs(await getLogs({ ...logQuery, page: nextPage, page_size: 1000 }))
+      const html = normalized.lines.map(renderLogLine).join('')
+      setHasMoreLogs(normalized.has_more)
+      setPreviewHtml((prev) => `${prev}${html}`)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Error loading logs'
+      showAlert(message, 'danger')
+    } finally {
+      loadingRef.current = false
+      setIsLoadingLogs(false)
+    }
+  }, [hasMoreLogs, logQuery, showAlert])
+
+  const handleDownloadLogs = useCallback(async () => {
+    if (downloadBusy) {
+      return
+    }
+    setDownloadBusy(true)
+    try {
+      const response = await fetch(getLogsDownloadUrl(logQuery), { credentials: 'same-origin' })
+      if (!response.ok) {
+        throw new Error('Error downloading logs')
+      }
+      const blob = await response.blob()
+      const url = window.URL.createObjectURL(blob)
+      const link = document.createElement('a')
+      link.href = url
+      link.download = `logs_${new Date().toISOString()}.zip`
+      document.body.appendChild(link)
+      link.click()
+      window.URL.revokeObjectURL(url)
+      link.remove()
+      showAlert('Logs downloaded successfully', 'success')
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Error downloading logs'
+      showAlert(message, 'danger')
+    } finally {
+      setDownloadBusy(false)
+    }
+  }, [downloadBusy, logQuery, showAlert])
+
+  const handleClearLogs = useCallback(async () => {
+    if (clearBusy) {
+      return
+    }
+    setClearBusy(true)
+    try {
+      const response = await clearLogs(logType)
+      const message =
+        response && typeof response === 'object' && typeof (response as { message?: unknown }).message === 'string'
+          ? String((response as { message: string }).message)
+          : 'Logs cleared successfully'
+      showAlert(message, 'success')
+      await loadLogs(true)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Error clearing logs'
+      showAlert(message, 'danger')
+    } finally {
+      setClearBusy(false)
+    }
+  }, [clearBusy, loadLogs, logType, showAlert])
+
+  const updateJavascriptLogging = useCallback((enabled: boolean) => {
+    const globalWindow = window as unknown as {
+      GLOBAL_JS_LOGGING_ENABLED?: boolean
+      webLogger?: { enable?: (value: boolean) => void }
+    }
+    sessionStorage.setItem('GLOBAL_JS_LOGGING_ENABLED', String(enabled))
+    localStorage.setItem('webLogger.enabled', String(enabled))
+    globalWindow.GLOBAL_JS_LOGGING_ENABLED = enabled
+    if (globalWindow.webLogger && typeof globalWindow.webLogger.enable === 'function') {
+      globalWindow.webLogger.enable(enabled)
+    }
+  }, [])
+
+  const handleSaveAndRestart = useCallback(async () => {
+    if (saveBusy) {
+      return
+    }
+    setSaveBusy(true)
+    try {
+      updateJavascriptLogging(javascriptLogsEnabled)
+      await saveLogSettings({ log: logSettings.log, level: logSettings.level, werkzeug: logSettings.werkzeug })
+      showAlert('Log configuration updated. Restart the application to apply the changes.', 'success')
+      setTimeout(() => {
+        fetch('/api/restart', { method: 'POST', credentials: 'same-origin' })
+          .catch(() => null)
+          .finally(() => {
+            showAlert('The application is restarting...', 'success')
+            setTimeout(() => window.location.reload(), 3000)
+          })
+      }, 1000)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Error updating log configuration'
+      showAlert(message, 'danger')
+    } finally {
+      setSaveBusy(false)
+    }
+  }, [
+    javascriptLogsEnabled,
+    logSettings.level,
+    logSettings.log,
+    logSettings.werkzeug,
+    saveBusy,
+    showAlert,
+    updateJavascriptLogging,
+  ])
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        setLogSettings(normalizeLogSettings(await getLogSettings()))
+      } catch {
+        // Keep default log settings when the request fails.
+      }
+    })()
+  }, [])
+
+  useEffect(() => {
+    const stored = sessionStorage.getItem('GLOBAL_JS_LOGGING_ENABLED')
+    if (stored !== null) {
+      setJavascriptLogsEnabled(stored === 'true')
+      return
+    }
+    const enabled = localStorage.getItem('webLogger.enabled') === 'true'
+    sessionStorage.setItem('GLOBAL_JS_LOGGING_ENABLED', String(enabled))
+    setJavascriptLogsEnabled(enabled)
+  }, [])
+
+  useEffect(() => {
+    void loadLogs(true)
+  }, [loadLogs])
+
+  const handlePreviewScroll = useCallback(() => {
+    if (!previewRef.current || isLoadingLogs || !hasMoreLogs) {
+      return
+    }
+    const { scrollTop, clientHeight, scrollHeight } = previewRef.current
+    if (scrollHeight - (scrollTop + clientHeight) < 200) {
+      void loadMoreLogs()
+    }
+  }, [hasMoreLogs, isLoadingLogs, loadMoreLogs])
+
+  return {
+    alert,
+    clearBusy,
+    dateRange,
+    downloadBusy,
+    handleClearLogs,
+    handleDownloadLogs,
+    handlePreviewScroll,
+    handleSaveAndRestart,
+    hasMoreLogs,
+    isLoadingLogs,
+    javascriptLogsEnabled,
+    loadLogs,
+    loadMoreLogs,
+    logCountText,
+    logLevel,
+    logSettings,
+    logType,
+    logsLoaded,
+    previewHtml,
+    previewRef,
+    refreshBusy,
+    saveBusy,
+    setDateRange,
+    setJavascriptLogsEnabled,
+    setLogLevel,
+    setLogSettings,
+    setLogType,
+    showAlert,
+    updateJavascriptLogging,
+  }
+}

--- a/nutify/frontend/app/src/lib/api/auth.ts
+++ b/nutify/frontend/app/src/lib/api/auth.ts
@@ -33,7 +33,28 @@ const authEnvelope = z.object({
   permissions: authStatusSchema.shape.permissions,
 })
 
+const oidcConfigSchema = z.object({
+  enabled: z.boolean(),
+  login_url: z.string(),
+  provider_name: z.string(),
+  button_label: z.string(),
+})
+
 export type AuthStatus = z.infer<typeof authStatusSchema>
+export type OidcConfig = z.infer<typeof oidcConfigSchema>
+
+export async function getOidcConfig(): Promise<OidcConfig> {
+  try {
+    return await requestJson('/auth/api/oidc', oidcConfigSchema)
+  } catch {
+    return {
+      enabled: false,
+      login_url: '/auth/oidc/login',
+      provider_name: 'SSO',
+      button_label: 'Sign in with SSO',
+    }
+  }
+}
 
 export async function getAuthStatus(): Promise<AuthStatus> {
   const payload = await requestJson('/auth/api/status', authEnvelope)

--- a/nutify/frontend/app/src/lib/api/auth.ts
+++ b/nutify/frontend/app/src/lib/api/auth.ts
@@ -35,6 +35,7 @@ const authEnvelope = z.object({
 
 const oidcConfigSchema = z.object({
   enabled: z.boolean(),
+  auto_redirect: z.boolean().optional().default(false),
   login_url: z.string(),
   provider_name: z.string(),
   button_label: z.string(),
@@ -49,6 +50,7 @@ export async function getOidcConfig(): Promise<OidcConfig> {
   } catch {
     return {
       enabled: false,
+      auto_redirect: false,
       login_url: '/auth/oidc/login',
       provider_name: 'SSO',
       button_label: 'Sign in with SSO',

--- a/nutify/requirements.txt
+++ b/nutify/requirements.txt
@@ -24,6 +24,12 @@ kaleido==0.2.1; python_version >= "3.13"
 # Security headers and CSP
 Flask-Talisman==1.1.0
 
+# OIDC / OpenID Connect single sign-on (generic provider support)
+# Pinned to 1.6.5: the last release that depends only on cryptography (>=1.7 pulls
+# joserfc>=1.6.0 which requires cryptography>=45.0.1 and would conflict with the
+# cryptography==44.0.2 pin above).
+Authlib==1.6.5
+
 # Socket UPS
 flask-socketio==5.5.1
 python-socketio==5.13.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,7 @@ def oidc_env(monkeypatch):
         'OIDC_PROVIDER_NAME',
         'OIDC_BUTTON_LABEL',
         'OIDC_REDIRECT_URI',
+        'OIDC_AUTO_REDIRECT',
     ):
         monkeypatch.delenv(key, raising=False)
     return monkeypatch

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,123 @@
+"""Shared fixtures for the OIDC SSO test suite.
+
+The Nutify runtime package (``core.db.ups``) pulls a heavy dependency chain
+(flask-socketio, pandas, eventlet, ...). These tests only exercise the
+authentication logic, so we load the relevant source files standalone via
+``importlib`` and inject a lightweight fake ``core.db.ups`` module that exposes
+the in-memory test database. This keeps the suite fast and free of the full
+application stack while still running the real production code paths.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from flask import Flask
+from flask_sqlalchemy import SQLAlchemy
+
+NUTIFY_DIR = Path(__file__).resolve().parents[1] / 'nutify'
+
+
+def _load_source(module_name: str, relative_path: str):
+    """Load a single source file as a standalone module."""
+    source_path = NUTIFY_DIR / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, source_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope='session')
+def oidc():
+    """The OIDC module under test, loaded without the heavy app stack."""
+    return _load_source('nutify_oidc_under_test', 'core/auth/oidc.py')
+
+
+@pytest.fixture(scope='session')
+def auth_stack():
+    """Flask app, in-memory DB, LoginAuth model and auth module wired together."""
+    app = Flask(__name__)
+    app.config['SECRET_KEY'] = 'test-secret-key'
+    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///:memory:'
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
+    db = SQLAlchemy(app)
+
+    # Inject a lightweight fake package chain so the model's lazy
+    # ``from core.db.ups import db`` resolves to our test database.
+    injected = {}
+    core_mod = types.ModuleType('core')
+    core_mod.__path__ = []
+    core_db_mod = types.ModuleType('core.db')
+    core_db_mod.__path__ = []
+    core_db_ups_mod = types.ModuleType('core.db.ups')
+    core_db_ups_mod.db = db
+    core_mod.db = core_db_mod
+    core_db_mod.ups = core_db_ups_mod
+    for name, module in (
+        ('core', core_mod),
+        ('core.db', core_db_mod),
+        ('core.db.ups', core_db_ups_mod),
+    ):
+        injected[name] = sys.modules.get(name)
+        sys.modules[name] = module
+
+    orm = _load_source('nutify_orm_login_under_test', 'core/db/orm/orm_ups_login.py')
+    auth = _load_source('nutify_auth_under_test', 'core/auth/__init__.py')
+
+    login_model = orm.init_model(db.Model)
+    auth.init_auth_module(login_model)
+    auth.setup_session_config(app)
+
+    with app.app_context():
+        db.create_all()
+
+    yield types.SimpleNamespace(app=app, db=db, LoginAuth=login_model, auth=auth)
+
+    # Restore any modules we replaced.
+    for name, original in injected.items():
+        if original is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = original
+
+
+@pytest.fixture
+def db_session(auth_stack):
+    """Provide a clean database for each test and roll back afterwards."""
+    with auth_stack.app.app_context():
+        auth_stack.db.session.query(auth_stack.LoginAuth).delete()
+        auth_stack.db.session.commit()
+        yield auth_stack
+        auth_stack.db.session.rollback()
+
+
+@pytest.fixture
+def oidc_env(monkeypatch):
+    """Apply a baseline valid OIDC configuration; tests tweak as needed."""
+    env = {
+        'OIDC_ENABLED': 'true',
+        'OIDC_ISSUER': 'https://sso.example.com',
+        'OIDC_CLIENT_ID': 'nutify',
+        'OIDC_CLIENT_SECRET': 'secret',
+        'OIDC_ADMIN_GROUP': 'nutify-admins',
+    }
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    # Clear optional overrides so defaults are exercised.
+    for key in (
+        'OIDC_SCOPES',
+        'OIDC_USERNAME_CLAIM',
+        'OIDC_GROUPS_CLAIM',
+        'OIDC_USER_GROUP',
+        'OIDC_PROVIDER_NAME',
+        'OIDC_BUTTON_LABEL',
+        'OIDC_REDIRECT_URI',
+    ):
+        monkeypatch.delenv(key, raising=False)
+    return monkeypatch

--- a/tests/test_oidc_callback.py
+++ b/tests/test_oidc_callback.py
@@ -1,0 +1,108 @@
+"""Integration tests for the OIDC callback with a mocked provider.
+
+These tests replace the Authlib client with a fake so the full token-exchange
+and claim-resolution path runs without contacting a real identity provider.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeClient:
+    """Stand-in for an Authlib OAuth client."""
+
+    def __init__(self, token=None, userinfo=None, raise_on_token=False):
+        self._token = token or {}
+        self._userinfo = userinfo
+        self._raise_on_token = raise_on_token
+
+    def authorize_access_token(self):
+        if self._raise_on_token:
+            raise RuntimeError('state mismatch')
+        return self._token
+
+    def userinfo(self, token=None):
+        if self._userinfo is None:
+            raise RuntimeError('userinfo endpoint disabled')
+        return self._userinfo
+
+
+class _FakeOAuth:
+    def __init__(self, client):
+        self._client = client
+
+    def create_client(self, name):
+        return self._client
+
+
+@pytest.fixture
+def mock_provider(oidc, oidc_env, monkeypatch):
+    """Install a fake provider client and return a configuration helper."""
+
+    def _install(token=None, userinfo=None, raise_on_token=False):
+        client = _FakeClient(token=token, userinfo=userinfo, raise_on_token=raise_on_token)
+        monkeypatch.setattr(oidc, '_oauth', _FakeOAuth(client))
+        monkeypatch.setattr(oidc, '_registered', True)
+        return client
+
+    return _install
+
+
+def test_callback_resolves_admin_identity(oidc, mock_provider):
+    mock_provider(token={'userinfo': {'preferred_username': 'alice', 'groups': ['nutify-admins']}})
+    identity = oidc.complete_login()
+    assert identity['username'] == 'alice'
+    assert identity['role'] == 'administrator'
+    assert identity['groups'] == ['nutify-admins']
+
+
+def test_callback_resolves_regular_user(oidc, mock_provider):
+    mock_provider(token={'userinfo': {'preferred_username': 'bob', 'groups': ['staff']}})
+    identity = oidc.complete_login()
+    assert identity['username'] == 'bob'
+    assert identity['role'] == 'user'
+
+
+def test_callback_enriches_groups_from_userinfo_endpoint(oidc, mock_provider):
+    # id_token lacks groups; the userinfo endpoint supplies them.
+    mock_provider(
+        token={'userinfo': {'preferred_username': 'carol'}},
+        userinfo={'groups': ['nutify-admins']},
+    )
+    identity = oidc.complete_login()
+    assert identity['role'] == 'administrator'
+
+
+def test_callback_missing_username_raises(oidc, mock_provider):
+    mock_provider(token={'userinfo': {'groups': ['staff']}}, userinfo={})
+    with pytest.raises(oidc.OidcError):
+        oidc.complete_login()
+
+
+def test_callback_rejects_user_outside_authorized_groups(oidc, oidc_env, mock_provider):
+    # Gating on: a configured user group means non-members are rejected.
+    oidc_env.setenv('OIDC_USER_GROUP', 'nutify-users')
+    mock_provider(token={'userinfo': {'preferred_username': 'mallory', 'groups': ['strangers']}})
+    with pytest.raises(oidc.OidcError):
+        oidc.complete_login()
+
+
+def test_callback_allows_user_group_member_when_gating(oidc, oidc_env, mock_provider):
+    oidc_env.setenv('OIDC_USER_GROUP', 'nutify-users')
+    mock_provider(token={'userinfo': {'preferred_username': 'dave', 'groups': ['nutify-users']}})
+    identity = oidc.complete_login()
+    assert identity['username'] == 'dave'
+    assert identity['role'] == 'user'
+
+
+def test_callback_token_exchange_failure_raises(oidc, mock_provider):
+    mock_provider(raise_on_token=True)
+    with pytest.raises(oidc.OidcError):
+        oidc.complete_login()
+
+
+def test_complete_login_disabled_raises(oidc, oidc_env, monkeypatch):
+    monkeypatch.delenv('OIDC_ENABLED', raising=False)
+    with pytest.raises(oidc.OidcError):
+        oidc.complete_login()

--- a/tests/test_oidc_config.py
+++ b/tests/test_oidc_config.py
@@ -1,0 +1,84 @@
+"""Unit tests for OIDC configuration, enablement and claim parsing."""
+
+from __future__ import annotations
+
+
+def test_disabled_without_enabled_flag(oidc, oidc_env):
+    oidc_env.delenv('OIDC_ENABLED', raising=False)
+    assert oidc.is_oidc_enabled() is False
+
+
+def test_disabled_when_config_incomplete(oidc, oidc_env):
+    oidc_env.delenv('OIDC_CLIENT_SECRET', raising=False)
+    assert oidc.is_oidc_configured() is False
+    assert oidc.is_oidc_enabled() is False
+
+
+def test_enabled_with_full_config(oidc, oidc_env):
+    assert oidc.is_oidc_configured() is True
+    assert oidc.is_oidc_enabled() is True
+
+
+def test_public_config_hides_secrets(oidc, oidc_env):
+    oidc_env.setenv('OIDC_PROVIDER_NAME', 'Authentik')
+    config = oidc.get_public_config()
+    assert config['enabled'] is True
+    assert config['login_url'] == '/auth/oidc/login'
+    assert config['button_label'] == 'Sign in with Authentik'
+    serialized = str(config)
+    assert 'secret' not in serialized
+    assert 'sso.example.com' not in serialized
+
+
+def test_public_config_custom_button_label(oidc, oidc_env):
+    oidc_env.setenv('OIDC_BUTTON_LABEL', 'Company Login')
+    assert oidc.get_public_config()['button_label'] == 'Company Login'
+
+
+def test_scopes_always_include_openid(oidc, oidc_env):
+    oidc_env.setenv('OIDC_SCOPES', 'profile email')
+    assert oidc._get_scopes().split()[0] == 'openid'
+
+
+def test_scopes_default(oidc, oidc_env):
+    assert oidc._get_scopes() == 'openid profile email groups'
+
+
+def test_extract_username_priority(oidc, oidc_env):
+    claims = {'preferred_username': 'alice', 'email': 'alice@example.com', 'sub': 'uuid'}
+    assert oidc._extract_username(claims) == 'alice'
+
+
+def test_extract_username_falls_back_to_email(oidc, oidc_env):
+    claims = {'email': 'bob@example.com', 'sub': 'uuid'}
+    assert oidc._extract_username(claims) == 'bob@example.com'
+
+
+def test_extract_username_falls_back_to_sub(oidc, oidc_env):
+    assert oidc._extract_username({'sub': 'uuid-123'}) == 'uuid-123'
+
+
+def test_extract_username_empty_when_missing(oidc, oidc_env):
+    assert oidc._extract_username({'name': 'No Id'}) == ''
+
+
+def test_extract_username_custom_claim(oidc, oidc_env):
+    oidc_env.setenv('OIDC_USERNAME_CLAIM', 'nickname')
+    assert oidc._extract_username({'nickname': 'ace', 'sub': 'x'}) == 'ace'
+
+
+def test_extract_groups_from_list(oidc, oidc_env):
+    assert oidc._extract_groups({'groups': ['a', 'b']}) == ['a', 'b']
+
+
+def test_extract_groups_from_string(oidc, oidc_env):
+    assert oidc._extract_groups({'groups': 'a, b c'}) == ['a', 'b', 'c']
+
+
+def test_extract_groups_missing(oidc, oidc_env):
+    assert oidc._extract_groups({}) == []
+
+
+def test_extract_groups_custom_claim(oidc, oidc_env):
+    oidc_env.setenv('OIDC_GROUPS_CLAIM', 'roles')
+    assert oidc._extract_groups({'roles': ['admin']}) == ['admin']

--- a/tests/test_oidc_config.py
+++ b/tests/test_oidc_config.py
@@ -35,6 +35,24 @@ def test_public_config_custom_button_label(oidc, oidc_env):
     assert oidc.get_public_config()['button_label'] == 'Company Login'
 
 
+def test_auto_redirect_off_by_default(oidc, oidc_env):
+    assert oidc.is_auto_redirect() is False
+    assert oidc.get_public_config()['auto_redirect'] is False
+
+
+def test_auto_redirect_enabled_when_flag_set(oidc, oidc_env):
+    oidc_env.setenv('OIDC_AUTO_REDIRECT', 'true')
+    assert oidc.is_auto_redirect() is True
+    assert oidc.get_public_config()['auto_redirect'] is True
+
+
+def test_auto_redirect_requires_sso_enabled(oidc, oidc_env):
+    oidc_env.setenv('OIDC_AUTO_REDIRECT', 'true')
+    oidc_env.delenv('OIDC_ENABLED', raising=False)
+    assert oidc.is_auto_redirect() is False
+    assert oidc.get_public_config()['auto_redirect'] is False
+
+
 def test_scopes_always_include_openid(oidc, oidc_env):
     oidc_env.setenv('OIDC_SCOPES', 'profile email')
     assert oidc._get_scopes().split()[0] == 'openid'

--- a/tests/test_oidc_provisioning.py
+++ b/tests/test_oidc_provisioning.py
@@ -1,0 +1,102 @@
+"""Integration tests for SSO user provisioning and login."""
+
+from __future__ import annotations
+
+
+def test_creates_new_sso_user(db_session):
+    LoginAuth = db_session.LoginAuth
+    with db_session.app.app_context():
+        user = LoginAuth.get_or_create_oidc_user('alice', 'user')
+        assert user.id is not None
+        assert user.username == 'alice'
+        assert user.role == 'user'
+        assert user.is_admin is False
+        assert user.is_active is True
+
+
+def test_sso_user_has_unusable_local_password(db_session):
+    LoginAuth = db_session.LoginAuth
+    with db_session.app.app_context():
+        user = LoginAuth.get_or_create_oidc_user('alice', 'user')
+        assert user.check_password('') is False
+        assert user.check_password('anything') is False
+        assert user.password_hash.startswith('!')
+
+
+def test_admin_group_provisions_administrator(db_session):
+    LoginAuth = db_session.LoginAuth
+    with db_session.app.app_context():
+        user = LoginAuth.get_or_create_oidc_user('boss', 'administrator')
+        assert user.role == 'administrator'
+        assert user.is_admin is True
+
+
+def test_second_login_updates_role(db_session):
+    LoginAuth = db_session.LoginAuth
+    with db_session.app.app_context():
+        # The primary admin (id 1) is always created locally via setup first.
+        LoginAuth.create_user('admin', 'localpass', role='administrator', is_admin=True)
+
+        user = LoginAuth.get_or_create_oidc_user('carol', 'user')
+        user_id = user.id
+        assert user_id != 1
+        assert user.role == 'user'
+
+        promoted = LoginAuth.get_or_create_oidc_user('carol', 'administrator')
+        assert promoted.id == user_id  # same account, not a duplicate
+        assert promoted.role == 'administrator'
+        assert promoted.is_admin is True
+
+        # A later login without the admin group demotes again.
+        demoted = LoginAuth.get_or_create_oidc_user('carol', 'user')
+        assert demoted.id == user_id
+        assert demoted.role == 'user'
+        assert demoted.is_admin is False
+
+
+def test_second_login_does_not_duplicate(db_session):
+    LoginAuth = db_session.LoginAuth
+    with db_session.app.app_context():
+        LoginAuth.get_or_create_oidc_user('dave', 'user')
+        LoginAuth.get_or_create_oidc_user('dave', 'user')
+        assert LoginAuth.query.filter_by(username='dave').count() == 1
+
+
+def test_primary_admin_is_never_demoted(db_session):
+    """The local admin fallback (id 1) must survive an SSO login collision."""
+    LoginAuth = db_session.LoginAuth
+    with db_session.app.app_context():
+        admin = LoginAuth.create_user('admin', 'localpass', role='administrator', is_admin=True)
+        assert admin.id == 1
+
+        # An SSO login for the same username must not strip admin rights.
+        same = LoginAuth.get_or_create_oidc_user('admin', 'user')
+        assert same.id == 1
+        assert same.role == 'administrator'
+        assert same.is_admin is True
+        # Local password login for the fallback admin still works.
+        assert same.check_password('localpass') is True
+
+
+def test_reactivates_disabled_user(db_session):
+    LoginAuth = db_session.LoginAuth
+    with db_session.app.app_context():
+        LoginAuth.create_user('admin', 'localpass', role='administrator', is_admin=True)
+
+        user = LoginAuth.get_or_create_oidc_user('erin', 'user')
+        user.is_active = False
+        db_session.db.session.commit()
+
+        reactivated = LoginAuth.get_or_create_oidc_user('erin', 'user')
+        assert reactivated.is_active is True
+
+
+def test_login_oidc_user_establishes_session(db_session):
+    auth = db_session.auth
+    with db_session.app.test_request_context():
+        user = auth.login_oidc_user('frank', 'administrator')
+        assert user is not None
+        assert auth.is_authenticated() is True
+        current = auth.get_current_user()
+        assert current['username'] == 'frank'
+        assert current['role'] == 'administrator'

--- a/tests/test_oidc_role_mapping.py
+++ b/tests/test_oidc_role_mapping.py
@@ -1,0 +1,67 @@
+"""Unit tests for the group -> role mapping."""
+
+from __future__ import annotations
+
+
+def test_admin_group_maps_to_administrator(oidc, oidc_env):
+    assert oidc.resolve_role(['nutify-admins']) == 'administrator'
+
+
+def test_admin_group_is_case_insensitive(oidc, oidc_env):
+    assert oidc.resolve_role(['Nutify-Admins']) == 'administrator'
+
+
+def test_non_admin_maps_to_user_when_no_user_group(oidc, oidc_env):
+    # No OIDC_USER_GROUP configured: everyone who is not an admin is a user.
+    assert oidc.resolve_role(['some-team']) == 'user'
+
+
+def test_no_groups_maps_to_user_when_no_user_group(oidc, oidc_env):
+    assert oidc.resolve_role([]) == 'user'
+
+
+def test_multiple_admin_groups(oidc, oidc_env):
+    oidc_env.setenv('OIDC_ADMIN_GROUP', 'ops, nutify-admins , infra')
+    assert oidc.resolve_role(['infra']) == 'administrator'
+
+
+def test_no_admin_group_configured(oidc, oidc_env):
+    oidc_env.delenv('OIDC_ADMIN_GROUP', raising=False)
+    assert oidc.resolve_role(['anything']) == 'user'
+
+
+def test_user_group_member_maps_to_user(oidc, oidc_env):
+    oidc_env.setenv('OIDC_USER_GROUP', 'nutify-users')
+    assert oidc.resolve_role(['nutify-users']) == 'user'
+
+
+def test_user_group_is_case_insensitive(oidc, oidc_env):
+    oidc_env.setenv('OIDC_USER_GROUP', 'nutify-users')
+    assert oidc.resolve_role(['Nutify-Users']) == 'user'
+
+
+def test_multiple_user_groups(oidc, oidc_env):
+    oidc_env.setenv('OIDC_USER_GROUP', 'staff, nutify-users , guests')
+    assert oidc.resolve_role(['guests']) == 'user'
+
+
+def test_gating_rejects_member_of_no_group(oidc, oidc_env):
+    # With a user group configured, a user in neither group is rejected.
+    oidc_env.setenv('OIDC_USER_GROUP', 'nutify-users')
+    assert oidc.resolve_role(['some-other-team']) is None
+
+
+def test_gating_rejects_when_user_has_no_groups(oidc, oidc_env):
+    oidc_env.setenv('OIDC_USER_GROUP', 'nutify-users')
+    assert oidc.resolve_role([]) is None
+
+
+def test_admin_wins_over_user_group(oidc, oidc_env):
+    oidc_env.setenv('OIDC_USER_GROUP', 'nutify-users')
+    assert oidc.resolve_role(['nutify-admins', 'nutify-users']) == 'administrator'
+
+
+def test_admin_allowed_even_when_gating_active(oidc, oidc_env):
+    # Admin membership grants access regardless of user-group gating.
+    oidc_env.setenv('OIDC_USER_GROUP', 'nutify-users')
+    assert oidc.resolve_role(['nutify-admins']) == 'administrator'


### PR DESCRIPTION
## Summary

Adds generic OpenID Connect (OIDC) single sign-on to Nutify, working with any
standards-compliant provider (Authentik, Keycloak, Authelia, Zitadel, …). SSO is
fully opt-in and additive: local username/password login keeps working unchanged,
and the primary admin (user id 1) is always preserved as a fallback.

## Features

- **Generic OIDC Authorization Code flow** (via Authlib), configured entirely
  through environment variables. Disabled by default (`OIDC_ENABLED=false`).
- **Auto-provisioning** of SSO users on first login. SSO accounts get an unusable
  local password (`!oidc:` prefix) so they can only authenticate via the provider.
- **Group → role mapping**, kept deliberately simple:
  - `OIDC_ADMIN_GROUP` (comma-separated) → `administrator`.
  - `OIDC_USER_GROUP` (comma-separated, optional) → `user`.
  - The admin group always wins.
  - If `OIDC_USER_GROUP` is **empty**, every authenticated non-admin becomes `user`.
  - If `OIDC_USER_GROUP` is **set**, login is **gated**: only members of the admin
    or user group may sign in; everyone else is rejected and not provisioned.
  - A user's role is re-aligned with their group membership on every login.
- **Optional auto-redirect** (`OIDC_AUTO_REDIRECT=true`): the login page forwards
  straight to the provider, both server-side (302) and client-side (SPA). A
  loop-safe escape hatch — `/auth/login?local=1` — always renders the local form,
  so the primary admin can still log in even with auto-redirect enabled.
- The primary admin (id 1) is **never** modified by SSO, regardless of group claims.

## Configuration

| Variable | Required | Default | Purpose |
|---|---|---|---|
| `OIDC_ENABLED` | — | `false` | Master switch |
| `OIDC_ISSUER` | yes | — | Provider issuer URL (OIDC discovery) |
| `OIDC_CLIENT_ID` | yes | — | Client ID |
| `OIDC_CLIENT_SECRET` | yes | — | Client secret |
| `OIDC_REDIRECT_URI` | yes | — | Callback URL (`…/auth/oidc/callback`) |
| `OIDC_SCOPES` | — | `openid profile email groups` | Requested scopes |
| `OIDC_USERNAME_CLAIM` | — | `preferred_username` | Falls back to email → sub |
| `OIDC_GROUPS_CLAIM` | — | `groups` | Claim holding group names |
| `OIDC_ADMIN_GROUP` | — | — | Groups mapped to `administrator` |
| `OIDC_USER_GROUP` | — | — | Groups mapped to `user` (enables gating) |
| `OIDC_PROVIDER_NAME` | — | `SSO` | Shown on the login button |
| `OIDC_BUTTON_LABEL` | — | `Sign in with {provider}` | Login button text |
| `OIDC_AUTO_REDIRECT` | — | `false` | Skip login page, go straight to provider |

See the README ("Group mapping" section) and the commented block in both
`docker-compose.yaml` files for full examples.

## Testing

- **Unit tests (48, all green):** config exposure, role mapping incl. gating /
  deny / admin-wins, provisioning (incl. id-1 protection and `!oidc:` passwords),
  callback happy-path and gating rejection, and the auto-redirect public config.
- **End-to-end integration tests** against a real Authentik `2026.8.0`
  (postgres + server + worker) driving the real Nutify Docker image through a real
  browser (Playwright). All passed:
  - Base SSO: admin-group user → administrator, no-group user → user, RBAC 403s on
    admin-only endpoints, primary admin id 1 untouched.
  - Auto-redirect: server 302 and client-side redirect to the provider, `?local=1`
    escape hatch, and loop-safety on a real `mismatching_state` failure.
  - Group model: gating OFF (admin group only) and gating ON (admin + user group),
    verifying admin-wins, user-group allowed, no-group user **rejected and not
    provisioned** (confirmed in the DB), and local admin fallback under gating.

## Notes

- No changes to existing behaviour when `OIDC_ENABLED=false`.
- Also restores a missing frontend logs-section controller module and adds a
  `.gitignore` for build artifacts, caches, and local scratch dirs.